### PR TITLE
chore: refactored form into its own njk file

### DIFF
--- a/src/main/steps/common/error/summary.njk
+++ b/src/main/steps/common/error/summary.njk
@@ -13,4 +13,3 @@
     "errorList": errorList
   }) }}
 {% endif %}
-

--- a/src/main/steps/common/error/summary.njk
+++ b/src/main/steps/common/error/summary.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
 {% if sessionErrors and sessionErrors.length > 0 %}
   {% set errorList = [] %}
   {% for item in sessionErrors %}

--- a/src/main/steps/common/form/form.njk
+++ b/src/main/steps/common/form/form.njk
@@ -1,0 +1,49 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+<form class="form" id="main-form" method="post" action="" novalidate="novalidate">
+  <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+  {% block form_content %}
+    {% for fieldName, field in form.fields %}
+      {% switch field.type %}
+        {% case 'radios' %}
+          {{ govukRadios({
+              classes: field.classes,
+              idPrefix: fieldName,
+              name: fieldName,
+              fieldset: {
+                legend: {
+                  text: getContent(field.label),
+                  classes: "govuk-fieldset__legend--l"
+                }
+              },
+              items: formItems(field.values)
+            }) }}
+        {% case 'option' %}
+          {{ govukSelect({
+            id: fieldName,
+            name: fieldName,
+            label: {
+              text: getContent(field.label)
+            },
+            items: formItems(field.values)
+          }) }}
+        {% default %}
+          {{ govukInput({
+            label: {
+              text: getContent(field.label),
+              classes: "govuk-label--l " + field.classes
+            },
+            id: fieldName,
+            name: fieldName
+          }) }}
+      {% endswitch %}
+    {% endfor %}
+  {% endblock %}
+
+  <div class="govuk-form-group">
+    {{ govukButton({ text: getContent(form.submit.text), preventDoubleClick: true }) }}
+  </div>
+</form>

--- a/src/main/steps/common/page.njk
+++ b/src/main/steps/common/page.njk
@@ -1,8 +1,3 @@
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/select/macro.njk" import govukSelect %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {% extends "govuk/template.njk" %}
@@ -50,54 +45,11 @@
       {% block page_content %}{% endblock %}
 
       {% if form %}
-        <form class="form" id="main-form" method="post" action="" novalidate>
-          <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-          {% block form_content %}
-            {% for fieldName, field in form.fields %}
-              {% if field.type === 'radios' %}
-                {{ govukRadios({
-                  classes: field.classes,
-                  idPrefix: fieldName,
-                  name: fieldName,
-                  fieldset: {
-                    legend: {
-                      text: getContent(field.label),
-                      classes: "govuk-fieldset__legend--l"
-                    }
-                  },
-                  items: formItems(field.values)
-                }) }}
-              {% elif field.type === 'option' %}
-                {{ govukSelect({
-                  id: fieldName,
-                  name: fieldName,
-                  label: {
-                    text: getContent(field.label)
-                  },
-                  items: formItems(field.values)
-                }) }}
-              {% else %}
-                {{ govukInput({
-                  label: {
-                    text: getContent(field.label),
-                    classes: "govuk-label--l " + field.classes
-                  },
-                  id: fieldName,
-                  name: fieldName
-                }) }}
-              {% endif %}
-            {% endfor %}
-          {% endblock %}
-
-          <div class="govuk-form-group">
-            {{ govukButton({ text: getContent(form.submit.text), preventDoubleClick: true }) }}
-          </div>
-        </form>
+        {% include "common/form/form.njk"%}
       {% endif %}
     </div>
   </div>
 {% endblock %}
-
 
 {% block bodyEnd %}
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

This refactors the form into it's own `njk` file and moves imports to their correct files.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
