### PR TITLE
fix: version /info endpoint & transform regex

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@
 !src/main/**
 !config/**
 !webpack.config.js
+!version

--- a/jest.a11y.config.js
+++ b/jest.a11y.config.js
@@ -7,7 +7,7 @@ module.exports = {
   ],
   testEnvironment: 'node',
   transform: {
-    '^.+\\.ts?$': 'ts-jest',
+    '^.+\\.ts$': 'ts-jest',
   },
   moduleFileExtensions: ['ts', 'js', 'json'],
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   ],
   testEnvironment: 'node',
   transform: {
-    '^.+\\.ts?$': 'ts-jest',
+    '^.+\\.ts$': 'ts-jest',
   },
   moduleFileExtensions: ['ts', 'js', 'json'],
 }

--- a/jest.smoke.config.js
+++ b/jest.smoke.config.js
@@ -7,7 +7,7 @@ module.exports = {
   ],
   testEnvironment: 'node',
   transform: {
-    '^.+\\.ts?$': 'ts-jest',
+    '^.+\\.ts$': 'ts-jest',
   },
   moduleFileExtensions: ['ts', 'js', 'json'],
 }

--- a/src/main/steps/error/error.controller.test.ts
+++ b/src/main/steps/error/error.controller.test.ts
@@ -8,10 +8,12 @@ import { ErrorController, HTTPError } from './error.controller';
 
 describe('ErrorController', () => {
   const logger = {
+    warn: jest.fn(),
     error: jest.fn()
   };
 
   afterEach(() => {
+    logger.warn.mockClear();
     logger.error.mockClear();
   });
 
@@ -22,7 +24,7 @@ describe('ErrorController', () => {
     const res = mockResponse();
     await controller.notFound(req, res);
 
-    expect(logger.error.mock.calls[0][0]).toContain('404 Not Found: /request');
+    expect(logger.warn.mock.calls[0][0]).toContain('404 Not Found: /request');
     expect(res.statusCode).toBe(404);
     expect(res.render).toBeCalledWith('error/error', { ...commonContent.en, ...errorContent.en[404] });
   });

--- a/src/main/steps/error/error.controller.test.ts
+++ b/src/main/steps/error/error.controller.test.ts
@@ -8,12 +8,12 @@ import { ErrorController, HTTPError } from './error.controller';
 
 describe('ErrorController', () => {
   const logger = {
-    warn: jest.fn(),
+    info: jest.fn(),
     error: jest.fn()
   };
 
   afterEach(() => {
-    logger.warn.mockClear();
+    logger.info.mockClear();
     logger.error.mockClear();
   });
 
@@ -24,7 +24,7 @@ describe('ErrorController', () => {
     const res = mockResponse();
     await controller.notFound(req, res);
 
-    expect(logger.warn.mock.calls[0][0]).toContain('404 Not Found: /request');
+    expect(logger.info.mock.calls[0][0]).toContain('404 Not Found: /request');
     expect(res.statusCode).toBe(404);
     expect(res.render).toBeCalledWith('error/error', { ...commonContent.en, ...errorContent.en[404] });
   });

--- a/src/main/steps/error/error.controller.ts
+++ b/src/main/steps/error/error.controller.ts
@@ -19,7 +19,7 @@ export class ErrorController {
    * Catch all for 404
    */
   public notFound(req: Request, res: Response): void {
-    this.logger.warn(`404 Not Found: ${req.originalUrl}`);
+    this.logger.info(`404 Not Found: ${req.originalUrl}`);
 
     res.status(StatusCodes.NOT_FOUND);
     this.render(req, res);

--- a/src/main/steps/error/error.controller.ts
+++ b/src/main/steps/error/error.controller.ts
@@ -19,7 +19,7 @@ export class ErrorController {
    * Catch all for 404
    */
   public notFound(req: Request, res: Response): void {
-    this.logger.error(`404 Not Found: ${req.originalUrl}`);
+    this.logger.warn(`404 Not Found: ${req.originalUrl}`);
 
     res.status(StatusCodes.NOT_FOUND);
     this.render(req, res);


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

Currently the `/info` endpoint returns unknown for the version information. The PR adds a missing required `version` file that is needed by the pipeline for this JSON response. This also fixes an unoptional `s` in transform regex for `ts-jest`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
