### PR TITLE
chore: use matching @types/node version for Node 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/glob": "^7.1.3",
     "@types/helmet": "^4.0.0",
     "@types/lodash": "^4.14.168",
-    "@types/node": "^13.7.0",
+    "@types/node": "^12.19.15",
     "@types/nunjucks": "^3.1.3",
     "@types/redis": "^2.8.28",
     "@types/require-directory": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,10 +1469,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.8.tgz#2127bd81949a95c8b7d3240f3254352d72563aec"
   integrity sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA==
 
-"@types/node@^13.7.0":
-  version "13.13.31"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.31.tgz#b8fc04d46bc22959a99fbdba71b15f37a48da3ec"
-  integrity sha512-gBk54XbcRj8EKTi7Syo4JU4purbRJaZpkvMVs7+t+b9JaOtwsGo7vCbXdVJN3gH/wu/GyZGD8lAKo0qpQuNjOw==
+"@types/node@^12.19.15":
+  version "12.19.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.15.tgz#0de7e978fb43db62da369db18ea088a63673c182"
+  integrity sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

Since we are using Node 12.x in the pipeline and `.nvmrc` we should also be using the correct/matching version of the TypeScript types for node.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
