### PR TITLE
fix: pa11y result checking and convert to async

### DIFF
--- a/src/test/a11y/a11y.ts
+++ b/src/test/a11y/a11y.ts
@@ -1,4 +1,3 @@
-import { fail } from 'assert';
 import { config } from '../config';
 import Axios from 'axios';
 
@@ -20,15 +19,11 @@ interface PallyIssue {
   typeCode: number
 }
 
-beforeAll((done /* call it or remove it*/) => {
-  done(); // calling it
-});
-
 function ensurePageCallWillSucceed(url: string): Promise<void> {
   return axios.get(url);
 }
 
-function runPally(url: string): Pa11yResult {
+function runPally(url: string): Promise<Pa11yResult> {
   return pa11y(config.TEST_URL + url, {
     hideElements: '.govuk-footer__licence-logo, .govuk-header__logotype-crown',
   });
@@ -39,20 +34,16 @@ function expectNoErrors(messages: PallyIssue[]): void {
 
   if (errors.length > 0) {
     const errorsAsJson = `${JSON.stringify(errors, null, 2)}`;
-    fail(`There are accessibility issues: \n${errorsAsJson}\n`);
+    throw new Error(`There are accessibility issues: \n${errorsAsJson}\n`);
   }
 }
 
 function testAccessibility(url: string): void {
   describe(`Page ${url}`, () => {
-    test('should have no accessibility errors', done => {
-      ensurePageCallWillSucceed(url)
-        .then(() => runPally(url))
-        .then((result: Pa11yResult) => {
-          expectNoErrors(result.issues);
-          done();
-        })
-        .catch((err: Error) => done(err));
+    test('should have no accessibility errors', async () => {
+      await ensurePageCallWillSucceed(url);
+      const result = await runPally(url);
+      expectNoErrors(result?.issues || []);
     });
   });
 }


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

Some PR pipelines are failing with the error:

```
FAIL src/test/a11y/a11y.ts
  Accessibility
    Page /
      ✕ should have no accessibility errors (184 ms)

  ● Accessibility › Page / › should have no accessibility errors

    TypeError: Cannot read property 'filter' of undefined

      32 | 
      33 | function expectNoErrors(messages: PallyIssue[]): void {
    > 34 |   const errors = messages.filter(m => m.type === 'error');
         |                           ^
```

This PR checks that a message result has be returned before trying to access it and converts to an async test.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
