### PR TITLE
fix: JS initialisation error

### DIFF
--- a/webpack/scss.js
+++ b/webpack/scss.js
@@ -15,7 +15,17 @@ module.exports = {
   rules: [
     {
       test: /\.scss$/,
-      use: ['style-loader', MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+      use: [
+        'style-loader',
+        {
+          loader: MiniCssExtractPlugin.loader,
+          options: {
+            esModule: false,
+          },
+        },
+        'css-loader',
+        'sass-loader',
+      ],
     },
   ],
   plugins: [miniCss],


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

JavaScript was failing to initialise with the following error message:

```
Uncaught TypeError: Cannot read property 'locals' of undefined
    at Module.<anonymous> (main.73b67d56493e451a2d6b.js:1)
    at n (main.73b67d56493e451a2d6b.js:1)
    at Object.<anonymous> (main.73b67d56493e451a2d6b.js:1)
    at n (main.73b67d56493e451a2d6b.js:1)
    at main.73b67d56493e451a2d6b.js:1
    at main.73b67d56493e451a2d6b.js:1
```

This PR  disables the `esModule` option in the `MiniCssExtractPlugin.loader`, which appeared to be causing the error.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
