### PR TITLE
feat(NFDIV-440): Send spouse to content + clear session on sign out

### DIFF
--- a/src/main/app/controller/AppRequest.ts
+++ b/src/main/app/controller/AppRequest.ts
@@ -19,5 +19,5 @@ export interface AppSession extends Session {
   userCase: Record<string, string> | undefined;
   lang: string | undefined;
   errors: FormError[] | undefined;
-  state: Record<string, unknown>;
+  state: Record<string, Record<string, string> | undefined>;
 }

--- a/src/main/app/controller/AppRequest.ts
+++ b/src/main/app/controller/AppRequest.ts
@@ -15,7 +15,8 @@ export interface AppRequest<T = Record<string, unknown>> extends Request {
 }
 
 export interface AppSession extends Session {
-  lang: string;
+  user: Record<string, unknown> | undefined;
+  lang: string | undefined;
   errors: FormError[] | undefined;
   state: Record<string, unknown>;
 }

--- a/src/main/app/controller/GetController.test.ts
+++ b/src/main/app/controller/GetController.test.ts
@@ -75,7 +75,7 @@ describe('GetController', () => {
       await controller.get(req, res);
 
       expect(getContentMock).toHaveBeenCalledTimes(1);
-      expect(getContentMock).toHaveBeenCalledWith({ isDivorce: true, partner: '' });
+      expect(getContentMock).toHaveBeenCalledWith({ isDivorce: true, partner: 'partner' });
       expect(res.render).toBeCalledWith('page', {
         ...commonContent.en,
         sessionErrors: [],
@@ -88,9 +88,10 @@ describe('GetController', () => {
     ])('Service type %s', ({ serviceType, isDivorce, civilKey }) => {
       describe.each(['en', 'cy'])('Language %s', lang => {
         test.each([
-          { partnerGender: 'Masculine', marriageKey: 'husband' },
-          { partnerGender: 'Feminine', marriageKey: 'wife' },
-        ])('calls getContent with correct arguments %s selected', async ({ partnerGender, marriageKey }) => {
+          { partnerGender: 'Masculine', partnerKey: 'husband' },
+          { partnerGender: 'Feminine', partnerKey: 'wife' },
+          { partnerKey: 'partner' },
+        ])('calls getContent with correct arguments %s selected', async ({ partnerGender, partnerKey }) => {
           const getContentMock = jest.fn().mockReturnValue({ [lang]: { pageText: `something in ${lang}` } });
           const controller = new GetController('page', getContentMock);
 
@@ -99,7 +100,7 @@ describe('GetController', () => {
           await controller.get(req, res);
 
           expect(getContentMock).toHaveBeenCalledTimes(1);
-          const expectedPartner = commonContent[lang][civilKey || marriageKey];
+          const expectedPartner = commonContent[lang][civilKey || partnerKey];
           expect(getContentMock).toHaveBeenCalledWith({ isDivorce, partner: expectedPartner });
           expect(res.render).toBeCalledWith('page', {
             ...commonContent[lang],

--- a/src/main/app/controller/GetController.ts
+++ b/src/main/app/controller/GetController.ts
@@ -6,7 +6,7 @@ import { commonContent } from '../../steps/common/common.content';
 import { AppRequest } from './AppRequest';
 
 export type Translations = Record<'en' | 'cy' | 'common', Record<string, unknown>>;
-export type TranslationFn = (isDivorce: boolean) => Translations;
+export type TranslationFn = ({ isDivorce, partner }: { isDivorce: boolean; partner: string }) => Translations;
 
 @autobind
 export class GetController {
@@ -23,13 +23,11 @@ export class GetController {
       return;
     }
 
-    const isDivorce = res.locals.serviceType !== 'civil';
-    const derivedContent = typeof this.content === 'function' ? this.content(isDivorce) : this.content;
-
     const language = req.session.lang || 'en';
-    const languageContent = derivedContent[language];
     const commonLanguageContent = commonContent[language];
-    const commonPageContent = derivedContent.common || {};
+    const content = this.getContent(req, res, commonLanguageContent);
+    const languageContent = content[language];
+    const commonPageContent = content.common || {};
 
     const sessionErrors = req.session.errors || [];
 
@@ -40,7 +38,27 @@ export class GetController {
       ...commonPageContent,
       ...commonLanguageContent,
       sessionErrors,
-      ...(this.stepId && { formState: req.session.state[this.stepId] }),
+      ...(this.stepId && { formState: req.session.state?.[this.stepId] }),
     });
+  }
+
+  private getContent(req: AppRequest, res: Response, translations: Translations): Translations {
+    if (typeof this.content !== 'function') {
+      return this.content;
+    }
+
+    const isDivorce = res.locals.serviceType !== 'civil';
+    const yourDetails = req.session.state?.['your-details'] as Record<string, string> | undefined;
+    const selectedPartnerGender = yourDetails?.partnerGender;
+    let partner = '';
+    if (selectedPartnerGender) {
+      if (!isDivorce) {
+        partner = translations['civilPartner'];
+      } else {
+        partner = selectedPartnerGender === 'Masculine' ? translations['husband'] : translations['wife'];
+      }
+    }
+
+    return this.content({ isDivorce, partner });
   }
 }

--- a/src/main/app/controller/GetController.ts
+++ b/src/main/app/controller/GetController.ts
@@ -48,17 +48,23 @@ export class GetController {
     }
 
     const isDivorce = res.locals.serviceType !== 'civil';
-    const yourDetails = req.session.state?.['your-details'] as Record<string, string> | undefined;
-    const selectedPartnerGender = yourDetails?.partnerGender;
-    let partner = '';
-    if (selectedPartnerGender) {
-      if (!isDivorce) {
-        partner = translations['civilPartner'];
-      } else {
-        partner = selectedPartnerGender === 'Masculine' ? translations['husband'] : translations['wife'];
-      }
-    }
 
-    return this.content({ isDivorce, partner });
+    const getPartner = (): string => {
+      if (!isDivorce) {
+        return translations['civilPartner'];
+      }
+
+      const selectedPartnerGender = req.session.state['your-details']?.partnerGender;
+      if (selectedPartnerGender === 'Masculine') {
+        return translations['husband'];
+      }
+      if (selectedPartnerGender === 'Feminine') {
+        return translations['wife'];
+      }
+
+      return translations['partner'];
+    };
+
+    return this.content({ isDivorce, partner: getPartner() });
   }
 }

--- a/src/main/app/controller/PostController.test.ts
+++ b/src/main/app/controller/PostController.test.ts
@@ -4,7 +4,6 @@ import { Form } from '../../app/form/Form';
 import { getNextStepUrl } from '../../steps/sequence';
 import { SIGN_OUT_URL } from '../../steps/urls';
 
-import { AppSession } from './AppRequest';
 import { PostController } from './PostController';
 
 jest.mock('../../steps/sequence');
@@ -23,8 +22,8 @@ describe('PostController', () => {
     const mockForm = ({ getErrors: () => errors } as unknown) as Form;
     const controller = new NewPostController(mockForm, 'test-step');
 
-    const req = mockRequest({ mockField: 'falafel' });
-    const res = mockResponse(req.session);
+    const req = mockRequest({ body: { mockField: 'falafel' } });
+    const res = mockResponse({ session: req.session });
     await controller.post(req, res);
 
     expect(res.locals.storage.getCurrentState()).toEqual({ 'test-step': { mockField: 'falafel' } });
@@ -40,8 +39,8 @@ describe('PostController', () => {
     const mockForm = ({ getErrors: () => errors } as unknown) as Form;
     const controller = new NewPostController(mockForm, 'test-step');
 
-    const req = mockRequest({ mockField: 'falafel' });
-    const res = mockResponse(req.session);
+    const req = mockRequest({ body: { mockField: 'falafel' } });
+    const res = mockResponse({ session: req.session });
     await controller.post(req, res);
 
     expect(res.locals.storage.getCurrentState()).toEqual({ 'test-step': { mockField: 'falafel' } });
@@ -56,8 +55,8 @@ describe('PostController', () => {
     const mockForm = ({ getErrors: () => errors } as unknown) as Form;
     const controller = new NewPostController(mockForm, 'test-step');
 
-    const req = mockRequest({ mockField: 'falafel', saveAndSignOut: true });
-    const res = mockResponse(req.session);
+    const req = mockRequest({ body: { mockField: 'falafel', saveAndSignOut: true } });
+    const res = mockResponse({ session: req.session });
     await controller.post(req, res);
 
     expect(res.locals.storage.getCurrentState()).toEqual({
@@ -75,8 +74,8 @@ describe('PostController', () => {
     const controller = new NewPostController(mockForm, 'test-step');
 
     const mockSave = jest.fn(done => done('An error while saving session'));
-    const req = mockRequest({ mockField: 'falafel' }, ({ save: mockSave } as unknown) as AppSession);
-    const res = mockResponse(req.session);
+    const req = mockRequest({ body: { mockField: 'falafel' }, session: { save: mockSave } });
+    const res = mockResponse({ session: req.session });
     await expect(controller.post(req, res)).rejects.toEqual('An error while saving session');
 
     expect(mockSave).toHaveBeenCalled();

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -57,9 +57,9 @@ export class OidcMiddleware {
     app.get(
       SIGN_OUT_URL,
       errorHandler((req: AppRequest, res) => {
-        delete req.session.user;
-        delete req.session.userCase;
-        delete req.session.lang;
+        req.session.user = undefined;
+        req.session.userCase = undefined;
+        req.session.lang = undefined;
         req.session.state = {};
         req.session.save(() => res.redirect('/'));
       })

--- a/src/main/modules/session/index.ts
+++ b/src/main/modules/session/index.ts
@@ -22,7 +22,9 @@ export class SessionStorage {
         secret: config.get('session.secret'),
         cookie: {
           httpOnly: true,
+          maxAge: 20 * (60 * 1000), // 20 minutes
         },
+        rolling: true, // Renew the cookie for another 20 minutes on each request
         store: this.getStore(),
       })
     );

--- a/src/main/steps/common/common.content.ts
+++ b/src/main/steps/common/common.content.ts
@@ -45,6 +45,7 @@ const en = {
   termsAndConditions: 'Terms and conditions',
   husband: 'husband',
   wife: 'wife',
+  civilPartner: 'civil partner',
   withHim: 'with him',
   withHer: 'with her',
   months: [
@@ -64,22 +65,18 @@ const en = {
 };
 
 const cy: typeof en = {
+  ...en, // @TODO delete me to get a list of missing translations
   phase: 'Beta',
   feedback:
     'Mae hwn yn wasanaeth newydd - <a class="govuk-link" aria-label="Dolen adborth, Bydd hyn yn agor tab newydd. Bydd angen ichi ddod yn ôl at y tab hwn a pharhau â’ch cais o fewn 60 munud fel na fyddwch yn colli’r gwaith yr ydych wedi ei wneud yn barod." href="https://www.smartsurvey.co.uk/s/Divorce_Feedback" target="_blank">bydd eich sylwadau</a> yn ein helpu i wella’r gwasanaeth.',
   languageToggle: '<a href="?lng=en" class="govuk-link language">English</a>',
   pageHeader: {
+    ...en.pageHeader, // @TODO delete me to get a list of missing translations
     divorce: 'Gwneud cais am ysgariad',
-    civil: 'TODO',
-  },
-  pageTitle: {
-    divorce: 'Divorce - GOV.UK',
-    civil: 'Civil partnership - GOV.UK',
   },
   back: 'Yn ôl',
   continue: 'Parhau',
   download: 'Llwytho i lawr',
-  warning: 'Warning',
   ogl:
     'Mae’r holl gynnwys ar gael o dan <a class="govuk-link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license" >Drwydded Agored y Llywodraeth f3.0</a>, oni nodir fel arall',
   cookieText:

--- a/src/main/steps/common/common.content.ts
+++ b/src/main/steps/common/common.content.ts
@@ -46,6 +46,7 @@ const en = {
   husband: 'husband',
   wife: 'wife',
   civilPartner: 'civil partner',
+  partner: 'partner',
   withHim: 'with him',
   withHer: 'with her',
   months: [

--- a/src/main/steps/common/form/form.njk
+++ b/src/main/steps/common/form/form.njk
@@ -66,7 +66,7 @@
     }) }}
 
     <p class="govuk-body">
-      <button class="hmcts-button-link" type="submit" name="saveAndSignOut" value="true"/>
+      <button class="hmcts-button-link" type="submit" name="saveAndSignOut" value="true" data-prevent-double-click="true" data-module="govuk-button" />
         {{ saveAndSignOut }}
       </button>
     </p>

--- a/src/main/steps/sequence.ts
+++ b/src/main/steps/sequence.ts
@@ -24,7 +24,7 @@ const sequence: Step[] = [
   },
   {
     id: 'has-relationship-broken',
-    title: 'Has you marriage irretrievably broken down (it cannot be saved)?',
+    title: 'Has your marriage irretrievably broken down (it cannot be saved)?',
     field: 'screenHasUnionBroken',
     url: HAS_RELATIONSHIP_BROKEN_URL,
     subSteps: [

--- a/src/main/steps/sequence/has-relationship-broken/content.ts
+++ b/src/main/steps/sequence/has-relationship-broken/content.ts
@@ -1,7 +1,8 @@
+import { TranslationFn } from '../../../app/controller/GetController';
 import { FormContent } from '../../../app/form/Form';
 import { isFieldFilledIn } from '../../../app/form/validation';
 
-export const generateContent = (title: string) => (isDivorce: boolean): Record<string, unknown> => {
+export const generateContent = (title: string): TranslationFn => ({ isDivorce }) => {
   const en = {
     title: isDivorce ? title : 'Has your relationship irretrievably broken down (it cannot be saved)?',
     line1: `Your ${isDivorce ? 'marriage' : 'relationship'} must have irretrievably broken down for you to

--- a/src/main/steps/sequence/relationship-not-broken/content.ts
+++ b/src/main/steps/sequence/relationship-not-broken/content.ts
@@ -1,4 +1,6 @@
-export const generateContent = (title: string) => (isDivorce: boolean): Record<string, unknown> => {
+import { TranslationFn } from '../../../app/controller/GetController';
+
+export const generateContent = (title: string): TranslationFn => ({ isDivorce }) => {
   const en = {
     title: isDivorce ? title : 'You cannot apply to end your civil partnership',
     line1: `Your ${isDivorce ? 'marriage' : 'relationship'} must have irretrievably broken down

--- a/src/main/steps/sequence/your-details/content.ts
+++ b/src/main/steps/sequence/your-details/content.ts
@@ -1,7 +1,8 @@
+import { TranslationFn } from '../../../app/controller/GetController';
 import { FormContent } from '../../../app/form/Form';
 import { isFieldFilledIn } from '../../../app/form/validation';
 
-export const generateContent = (title: string) => (isDivorce: boolean): Record<string, unknown> => {
+export const generateContent = (title: string): TranslationFn => ({ isDivorce }) => {
   const en = {
     title: isDivorce ? title : 'Are you male or female?',
     masculine: isDivorce ? 'My husband' : 'Male',

--- a/src/test/unit/utils/mockRequest.ts
+++ b/src/test/unit/utils/mockRequest.ts
@@ -1,6 +1,6 @@
-import { AppRequest, AppSession } from '../../../main/app/controller/AppRequest';
+import { AppRequest } from '../../../main/app/controller/AppRequest';
 
-export const mockRequest = (body = {}, session?: AppSession): AppRequest<never> =>
+export const mockRequest = ({ session = {}, body = {} } = {}): AppRequest<never> =>
   (({
     body,
     scope: {

--- a/src/test/unit/utils/mockResponse.ts
+++ b/src/test/unit/utils/mockResponse.ts
@@ -3,7 +3,7 @@ import { Response } from 'express';
 import { AppSession } from '../../../main/app/controller/AppRequest';
 import { SessionStateStorage } from '../../../main/app/step/SessionStateStorage';
 
-export const mockResponse = (session?: AppSession): Response<Record<string, unknown>> => {
+export const mockResponse = ({ session = {}, locals = {} } = {}): Response<Record<string, unknown>> => {
   const res = ({
     locals: {
       storage: new SessionStateStorage(({
@@ -11,6 +11,7 @@ export const mockResponse = (session?: AppSession): Response<Record<string, unkn
         save: jest.fn(done => done()),
         ...session,
       } as unknown) as AppSession),
+      ...locals,
     },
   } as unknown) as Response<Record<string, unknown>>;
   res.redirect = jest.fn().mockReturnValue(res);


### PR DESCRIPTION
### JIRA link ###

Part of [NFDIV-440](https://tools.hmcts.net/jira/browse/NFDIV-440) English Version - Who are you applying to divorce / end a civil partnership with

### Change description ###

* Clears session details on sign out and set cookie timeout to 20 minutes
* Sends the spouse/partner type onto the current content e.g.

```ts
export const generateContent = (): TranslationFn => ({ isDivorce, partner })
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
