### PR TITLE
fix: handle a service type switch

### DIFF
--- a/src/main/app/api/to-api-format.test.ts
+++ b/src/main/app/api/to-api-format.test.ts
@@ -6,6 +6,7 @@ describe('to-api-format', () => {
   const results = {
     sameSex: 'checked',
     partnerGender: Gender.Male,
+    relationshipDate: '',
   };
 
   test('Should convert results from nfdiv to api fe format', async () => {
@@ -15,6 +16,7 @@ describe('to-api-format', () => {
       D8MarriageIsSameSexCouple: YesOrNo.Yes,
       D8InferredRespondentGender: Gender.Male,
       D8InferredPetitionerGender: Gender.Male,
+      D8MarriageDate: '',
     });
   });
 });

--- a/src/main/app/api/to-api-format.ts
+++ b/src/main/app/api/to-api-format.ts
@@ -15,11 +15,14 @@ const fields = {
         : Gender.Female,
   }),
   relationshipDate: data => ({
-    D8MarriageDate: data.relationshipDate ? toApiDate(data.relationshipDate) : '',
+    D8MarriageDate: toApiDate(data.relationshipDate),
   }),
 };
 
 const toApiDate = (date: CaseDate) => {
+  if (!date.year || !date.month || !date.day) {
+    return '';
+  }
   return date.year + '-' + date.month.padStart(2, '0') + '-' + date.day.padStart(2, '0');
 };
 

--- a/src/main/app/api/to-api-format.ts
+++ b/src/main/app/api/to-api-format.ts
@@ -20,7 +20,7 @@ const fields = {
 };
 
 const toApiDate = (date: CaseDate) => {
-  if (!date.year || !date.month || !date.day) {
+  if (!date?.year || !date?.month || !date?.day) {
     return '';
   }
   return date.year + '-' + date.month.padStart(2, '0') + '-' + date.day.padStart(2, '0');

--- a/src/main/app/controller/GetController.test.ts
+++ b/src/main/app/controller/GetController.test.ts
@@ -2,7 +2,7 @@ import { mockRequest } from '../../../test/unit/utils/mockRequest';
 import { mockResponse } from '../../../test/unit/utils/mockResponse';
 import { commonContent } from '../../steps/common/common.content';
 import { YOUR_DETAILS_URL } from '../../steps/urls';
-import { Gender } from '../api/case';
+import { CaseType, Gender } from '../api/case';
 
 import { GetController, Translations } from './GetController';
 
@@ -123,8 +123,8 @@ describe('GetController', () => {
     });
 
     describe.each([
-      { serviceType: 'divorce', isDivorce: true },
-      { serviceType: 'civil', isDivorce: false, civilKey: 'civilPartner' },
+      { serviceType: CaseType.Divorce, isDivorce: true },
+      { serviceType: CaseType.Dissolution, isDivorce: false, civilKey: 'civilPartner' },
     ])('Service type %s', ({ serviceType, isDivorce, civilKey }) => {
       describe.each(['en', 'cy'])('Language %s', lang => {
         test.each([

--- a/src/main/app/controller/GetController.ts
+++ b/src/main/app/controller/GetController.ts
@@ -3,7 +3,7 @@ import { Response } from 'express';
 
 import { commonContent } from '../../steps/common/common.content';
 import { sequence } from '../../steps/sequence';
-import { Case, Gender } from '../api/case';
+import { Case, CaseType, Gender } from '../api/case';
 
 import { AppRequest } from './AppRequest';
 
@@ -55,7 +55,7 @@ export class GetController {
       return this.content;
     }
 
-    const isDivorce = res.locals.serviceType !== 'civil';
+    const isDivorce = res.locals.serviceType === CaseType.Divorce;
 
     return this.content({
       isDivorce,

--- a/src/main/app/controller/PostController.test.ts
+++ b/src/main/app/controller/PostController.test.ts
@@ -3,7 +3,7 @@ import { mockResponse } from '../../../test/unit/utils/mockResponse';
 import { Form } from '../../app/form/Form';
 import { getNextStepUrl } from '../../steps';
 import { SAVE_SIGN_OUT_URL } from '../../steps/urls';
-import { Gender } from '../api/case';
+import { CaseType, Gender } from '../api/case';
 
 import { PostController } from './PostController';
 
@@ -91,5 +91,22 @@ describe('PostController', () => {
     expect(getNextStepUrlMock).toBeCalledWith(req);
     expect(res.redirect).not.toHaveBeenCalled();
     expect(req.session.errors).toBe(undefined);
+  });
+
+  test('throws an error if the users case type does not match the service type', async () => {
+    getNextStepUrlMock.mockReturnValue('/next-step-url');
+    const errors = [] as never[];
+    const body = { divorceOrDissolution: CaseType.Dissolution, partnerGender: Gender.Female };
+    const mockForm = ({
+      getErrors: () => errors,
+      getParsedBody: () => body,
+    } as unknown) as Form;
+    const controller = new PostController(mockForm);
+
+    const req = mockRequest({ body });
+    const res = mockResponse();
+    await expect(controller.post(req, res)).rejects.toThrowError(
+      "User case type: dissolution doesn't match current service type: divorce"
+    );
   });
 });

--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as express from 'express';
 import * as nunjucks from 'nunjucks';
 
+import { CaseType } from '../../app/api/case';
 import { FormInput } from '../../app/form/Form';
 
 export class Nunjucks {
@@ -55,7 +56,8 @@ export class Nunjucks {
     app.use((req, res, next) => {
       res.locals.host = req.headers['x-forwarded-host'] || req.hostname;
       res.locals.pagePath = req.path;
-      res.locals.serviceType = res.locals.host.includes('civil') || 'forceCivilMode' in req.query ? 'civil' : 'divorce';
+      res.locals.serviceType =
+        res.locals.host.includes('civil') || 'forceCivilMode' in req.query ? CaseType.Dissolution : CaseType.Divorce;
       next();
     });
   }

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -84,7 +84,8 @@ export class OidcMiddleware {
 
             if (!req.session.userCase) {
               req.session.userCase = await req.scope?.cradle.api.createCase({
-                divorceOrDissolution: res.locals.serviceType === 'civil' ? CaseType.Dissolution : CaseType.Divorce,
+                divorceOrDissolution:
+                  res.locals.serviceType === CaseType.Dissolution ? CaseType.Dissolution : CaseType.Divorce,
               });
             }
           }
@@ -109,5 +110,5 @@ declare module 'express-session' {
 }
 
 export interface RequestWithScope<T = unknown> extends AppRequest<T> {
-  scope?: AwilixContainer;
+  scope: AwilixContainer;
 }

--- a/src/main/steps/accessibility-statement/content.ts
+++ b/src/main/steps/accessibility-statement/content.ts
@@ -1,6 +1,6 @@
-import { Translations } from '../../app/controller/GetController';
+import { TranslationFn } from '../../app/controller/GetController';
 
-export const generateContent = ({ isDivorce }: { isDivorce: boolean }): Translations => {
+export const generateContent: TranslationFn = ({ isDivorce }) => {
   const en = {
     title: 'Accessibility Statement',
     statement: `Accessibility statement for the ${

--- a/src/main/steps/accessibility-statement/get.test.ts
+++ b/src/main/steps/accessibility-statement/get.test.ts
@@ -1,5 +1,6 @@
 import { mockRequest } from '../../../test/unit/utils/mockRequest';
 import { mockResponse } from '../../../test/unit/utils/mockResponse';
+import { CaseType } from '../../app/api/case';
 import { commonContent } from '../common/common.content';
 
 import { generateContent } from './content';
@@ -14,7 +15,7 @@ describe('AccessibilityStatementGetController', () => {
     await controller.get(req, res);
 
     expect(res.render).toBeCalledWith(expect.anything(), {
-      ...generateContent({ isDivorce: true }).en,
+      ...generateContent({ isDivorce: true, partner: '', formState: {} }).en,
       ...commonContent.en,
       formState: req.session.userCase,
       hideBackButton: false,
@@ -25,12 +26,12 @@ describe('AccessibilityStatementGetController', () => {
   test('Should render the accessibility statement page', async () => {
     const req = mockRequest();
     const res = mockResponse();
-    res.locals.serviceType = 'civil';
+    res.locals.serviceType = CaseType.Dissolution;
 
     await controller.get(req, res);
 
     expect(res.render).toBeCalledWith(expect.anything(), {
-      ...generateContent({ isDivorce: false }).en,
+      ...generateContent({ isDivorce: false, partner: '', formState: {} }).en,
       ...commonContent.en,
       formState: req.session.userCase,
       hideBackButton: false,

--- a/src/main/steps/common/common.content.ts
+++ b/src/main/steps/common/common.content.ts
@@ -5,7 +5,7 @@ const en = {
   languageToggle: '<a href="?lng=cy" class="govuk-link language">Cymraeg</a>',
   pageHeader: {
     divorce: 'Apply for a divorce',
-    civil: 'End a civil partnership',
+    dissolution: 'End a civil partnership',
   },
   govUk: 'GOV.UK',
   back: 'Back',

--- a/src/main/steps/cookies/get.test.ts
+++ b/src/main/steps/cookies/get.test.ts
@@ -1,5 +1,6 @@
 import { mockRequest } from '../../../test/unit/utils/mockRequest';
 import { mockResponse } from '../../../test/unit/utils/mockResponse';
+import { CaseType } from '../../app/api/case';
 import { commonContent } from '../common/common.content';
 
 import { generateContent } from './content';
@@ -25,7 +26,7 @@ describe('CookiesGetController', () => {
   test('Should render the cookie page with civil content', async () => {
     const req = mockRequest();
     const res = mockResponse();
-    res.locals.serviceType = 'civil';
+    res.locals.serviceType = CaseType.Dissolution;
     await controller.get(req, res);
 
     expect(res.render).toBeCalledWith(expect.anything(), {

--- a/src/main/steps/home/get.test.ts
+++ b/src/main/steps/home/get.test.ts
@@ -1,5 +1,6 @@
 import { mockRequest } from '../../../test/unit/utils/mockRequest';
 import { mockResponse } from '../../../test/unit/utils/mockResponse';
+import { CaseType } from '../../app/api/case';
 import { YOUR_DETAILS_URL } from '../urls';
 
 import { HomeGetController } from './get';
@@ -12,6 +13,22 @@ describe('HomeGetController', () => {
     const res = mockResponse();
     await controller.get(req, res);
 
+    expect(res.redirect).toBeCalledWith(YOUR_DETAILS_URL);
+  });
+
+  test('resets user case if the service type has changed', async () => {
+    const req = mockRequest({ userCase: { emptyThisAnswer: 'I had filled out' } });
+    const res = mockResponse({
+      locals: { serviceType: CaseType.Dissolution },
+    });
+    await controller.get(req, res);
+
+    expect(req.scope.cradle.api.updateCase).toHaveBeenCalledWith('1234', {
+      id: '1234',
+      divorceOrDissolution: 'dissolution',
+      emptyThisAnswer: '',
+    });
+    expect(req.session.save).toHaveBeenCalled();
     expect(res.redirect).toBeCalledWith(YOUR_DETAILS_URL);
   });
 });

--- a/src/main/steps/home/get.ts
+++ b/src/main/steps/home/get.ts
@@ -1,10 +1,27 @@
 import { Response } from 'express';
 
-import { AppRequest } from '../../app/controller/AppRequest';
+import { AnyObject } from '../../app/controller/PostController';
+import { RequestWithScope } from '../../modules/oidc';
 import { getNextIncompleteStepUrl } from '../../steps';
 
 export class HomeGetController {
-  public async get(req: AppRequest, res: Response): Promise<void> {
+  public async get(req: RequestWithScope<AnyObject>, res: Response): Promise<void> {
+    if (req.session.userCase?.divorceOrDissolution !== res.locals.serviceType) {
+      // Clear current application if the user changes between the divorce and civil dissolution services
+      Object.assign(req.session.userCase, {
+        ...Object.keys(req.session.userCase)
+          .map(prop => ({ [prop]: '' }))
+          .reduce((previous, current) => ({ ...previous, ...current }), {}),
+        id: req.session.userCase.id,
+        divorceOrDissolution: res.locals.serviceType,
+      });
+
+      await req.scope?.cradle.api.updateCase(req.session.userCase.id, req.session.userCase);
+      await new Promise<void>((resolve, reject): void => {
+        req.session.save(err => (err ? reject(err) : resolve()));
+      });
+    }
+
     res.redirect(getNextIncompleteStepUrl(req));
   }
 }

--- a/src/test/functional/features/relationship-broken-down.feature
+++ b/src/test/functional/features/relationship-broken-down.feature
@@ -17,7 +17,8 @@ Feature: Relationship broken down
     Then the page should include "You cannot apply to get a divorce"
 
   Scenario: Selecting option for exit page for civil partnership
-    Given I go to '/irretrievable-breakdown?forceCivilMode'
+    Given I go to '/?forceCivilMode'
+    And I go to '/irretrievable-breakdown?forceCivilMode'
     When I select "No, my relationship has not irretrievably broken down"
     Then the page should include "This is the law in England and Wales."
     When I click "Continue"

--- a/src/test/functional/features/your-details-step.feature
+++ b/src/test/functional/features/your-details-step.feature
@@ -14,7 +14,8 @@ Feature: Your details step
     Then the page should include "Has your marriage irretrievably broken down (it cannot be saved)?"
 
   Scenario: Loading the your details for civil partnership
-    Given I go to '/your-details?forceCivilMode'
+    Given I go to '/?forceCivilMode'
+    And I go to '/your-details?forceCivilMode'
     Then I expect the page title to be "End a civil partnership - Are you male or female? - GOV.UK"
     And the page should include "Are you male or female?"
 

--- a/src/test/unit/utils/mockRequest.ts
+++ b/src/test/unit/utils/mockRequest.ts
@@ -1,6 +1,6 @@
-import { AppRequest } from '../../../main/app/controller/AppRequest';
+import { RequestWithScope } from '../../../main/modules/oidc';
 
-export const mockRequest = ({ session = {}, body = {}, cookies = {} } = {}): AppRequest<never> =>
+export const mockRequest = ({ session = {}, body = {}, cookies = {}, userCase = {} } = {}): RequestWithScope<never> =>
   (({
     body,
     scope: {
@@ -15,6 +15,7 @@ export const mockRequest = ({ session = {}, body = {}, cookies = {} } = {}): App
       userCase: {
         id: '1234',
         divorceOrDissolution: 'divorce',
+        ...userCase,
       },
       save: jest.fn(done => done()),
       destroy: jest.fn(done => done()),
@@ -25,4 +26,4 @@ export const mockRequest = ({ session = {}, body = {}, cookies = {} } = {}): App
     url: '/request',
     originalUrl: '/request',
     logout: jest.fn(),
-  } as unknown) as AppRequest<never>);
+  } as unknown) as RequestWithScope<never>);

--- a/src/test/unit/utils/mockResponse.ts
+++ b/src/test/unit/utils/mockResponse.ts
@@ -1,14 +1,16 @@
 import { Response } from 'express';
 
-export const mockResponse = ({ locals = {} } = {}): Response<Record<string, unknown>> => {
-  const res = { locals } as Response<Record<string, unknown>>;
+import { CaseType } from '../../../main/app/api/case';
+
+export const mockResponse = ({ locals = { serviceType: CaseType.Divorce } } = {}): Response => {
+  const res: Partial<Response> = { locals };
   res.redirect = jest.fn().mockReturnValue(res);
   res.render = jest.fn().mockReturnValue(res);
   res.cookie = jest.fn();
-  res.status = (code: number) => {
+  res.status = jest.fn().mockImplementation((code = 200) => {
     res.statusCode = code;
     return res;
-  };
+  });
 
-  return res;
+  return (res as unknown) as Response;
 };


### PR DESCRIPTION
### Change description ###

Handles an edge case where user starts completing application in divorce mode and then switches to the dissolution domain.

* If the user submits a step and users case type does not match the service type then throw up an error.
* If the user is signing in again reset their answers if the service type is not the same as their case type.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
