### PR TITLE
fix: inferred petitioner/respondent gender

### DIFF
--- a/src/main/app/case/case.ts
+++ b/src/main/app/case/case.ts
@@ -2,7 +2,7 @@ import { AnyObject } from '../controller/PostController';
 
 export const formFieldsToCaseMapping = {
   divorceOrDissolution: 'divorceOrDissolution',
-  partnerGender: 'D8InferredRespondentGender',
+  gender: 'D8InferredRespondentGender',
   screenHasUnionBroken: 'D8ScreenHasMarriageBroken',
   hasCertificate: 'D8ScreenHasMarriageCert',
   helpPayingNeeded: 'D8HelpWithFeesNeedHelp',
@@ -30,7 +30,7 @@ export type FieldFormats = Record<string, string | ((AnyObject) => AnyObject)>;
 
 export interface Case {
   divorceOrDissolution: CaseType;
-  partnerGender?: Gender;
+  gender?: Gender;
   sameSex?: Checkbox;
   screenHasUnionBroken?: YesOrNo;
   relationshipDate?: CaseDate;

--- a/src/main/app/case/from-api-format.test.ts
+++ b/src/main/app/case/from-api-format.test.ts
@@ -17,7 +17,7 @@ describe('from-api-format', () => {
     expect(nfdivFormat).toStrictEqual({
       divorceOrDissolution: 'divorce',
       sameSex: 'checked',
-      partnerGender: 'Male',
+      gender: 'Male',
       screenHasUnionBroken: 'YES',
       helpWithFeesRefNo: 'HWF-ABC-123',
     });

--- a/src/main/app/case/to-api-format.test.ts
+++ b/src/main/app/case/to-api-format.test.ts
@@ -1,11 +1,11 @@
 import { ApiCase } from './CaseApi';
-import { Checkbox, Gender, YesOrNo } from './case';
+import { Case, CaseType, Checkbox, Gender, YesOrNo } from './case';
 import { toApiFormat } from './to-api-format';
 
 describe('to-api-format', () => {
   const results = {
+    gender: Gender.Male,
     sameSex: Checkbox.Checked,
-    partnerGender: Gender.Male,
     relationshipDate: { year: '1900', month: '1', day: '4' },
     helpWithFeesRefNo: 'HWF-123-ABC',
   };
@@ -33,4 +33,48 @@ describe('to-api-format', () => {
       D8MarriageDate: '',
     });
   });
+
+  test.each([
+    {
+      gender: Gender.Male,
+      sameSex: Checkbox.Unchecked,
+      expected: { petitioner: Gender.Female, respondent: Gender.Male },
+    },
+    {
+      gender: Gender.Female,
+      sameSex: Checkbox.Unchecked,
+      expected: { petitioner: Gender.Male, respondent: Gender.Female },
+    },
+    {
+      gender: Gender.Male,
+      sameSex: Checkbox.Checked,
+      expected: { petitioner: Gender.Male, respondent: Gender.Male },
+    },
+    {
+      divorceOrDissolution: CaseType.Dissolution,
+      gender: Gender.Male,
+      sameSex: Checkbox.Unchecked,
+      expected: { petitioner: Gender.Male, respondent: Gender.Female },
+    },
+    {
+      divorceOrDissolution: CaseType.Dissolution,
+      gender: Gender.Female,
+      sameSex: Checkbox.Unchecked,
+      expected: { petitioner: Gender.Female, respondent: Gender.Male },
+    },
+    {
+      divorceOrDissolution: CaseType.Dissolution,
+      gender: Gender.Female,
+      sameSex: Checkbox.Checked,
+      expected: { petitioner: Gender.Female, respondent: Gender.Female },
+    },
+  ])(
+    'gets the correct inferred gender of the petitioner and respondent: %o',
+    ({ divorceOrDissolution = CaseType.Divorce, gender, sameSex, expected }) => {
+      expect(toApiFormat({ divorceOrDissolution, gender, sameSex } as Partial<Case>)).toMatchObject({
+        D8InferredPetitionerGender: expected.petitioner,
+        D8InferredRespondentGender: expected.respondent,
+      });
+    }
+  );
 });

--- a/src/main/app/controller/GetController.test.ts
+++ b/src/main/app/controller/GetController.test.ts
@@ -67,7 +67,7 @@ describe('GetController', () => {
 
     const req = mockRequest();
     const res = mockResponse();
-    req.session.userCase.partnerGender = Gender.Female;
+    req.session.userCase.gender = Gender.Female;
     await controller.get(req, res);
 
     expect(res.render).toBeCalledWith('page', {
@@ -77,7 +77,7 @@ describe('GetController', () => {
       formState: {
         id: '1234',
         divorceOrDissolution: 'divorce',
-        partnerGender: Gender.Female,
+        gender: Gender.Female,
       },
     });
   });
@@ -128,14 +128,14 @@ describe('GetController', () => {
     ])('Service type %s', ({ serviceType, isDivorce, civilKey }) => {
       describe.each(['en', 'cy'])('Language %s', lang => {
         test.each([
-          { partnerGender: Gender.Male, partnerKey: 'husband' },
-          { partnerGender: Gender.Female, partnerKey: 'wife' },
+          { gender: Gender.Male, partnerKey: 'husband' },
+          { gender: Gender.Female, partnerKey: 'wife' },
           { partnerKey: 'partner' },
-        ])('calls getContent with correct arguments %s selected', async ({ partnerGender, partnerKey }) => {
+        ])('calls getContent with correct arguments %s selected', async ({ gender, partnerKey }) => {
           const getContentMock = jest.fn().mockReturnValue({ [lang]: { pageText: `something in ${lang}` } });
           const controller = new GetController('page', getContentMock);
 
-          const req = mockRequest({ session: { lang, userCase: { partnerGender } } });
+          const req = mockRequest({ session: { lang, userCase: { gender } } });
           const res = mockResponse({ locals: { serviceType } });
           await controller.get(req, res);
 

--- a/src/main/app/controller/GetController.ts
+++ b/src/main/app/controller/GetController.ts
@@ -69,11 +69,11 @@ export class GetController {
       return translations['civilPartner'];
     }
 
-    const selectedPartnerGender = req.session.userCase?.partnerGender;
-    if (selectedPartnerGender === Gender.Male) {
+    const selectedGender = req.session.userCase?.gender;
+    if (selectedGender === Gender.Male) {
       return translations['husband'];
     }
-    if (selectedPartnerGender === Gender.Female) {
+    if (selectedGender === Gender.Female) {
       return translations['wife'];
     }
 

--- a/src/main/app/controller/PostController.test.ts
+++ b/src/main/app/controller/PostController.test.ts
@@ -25,7 +25,8 @@ describe('PostController', () => {
     const res = mockResponse();
     await controller.post(req, res);
 
-    expect(req.session.userCase?.gender).toEqual(Gender.Female);
+    expect(req.session.userCase).toEqual({ divorceOrDissolution: 'divorce', gender: 'female', id: '1234' });
+    expect(req.locals.api.updateCase).not.toHaveBeenCalled();
 
     expect(getNextStepUrlMock).toBeCalledWith(req);
     expect(res.redirect).toBeCalledWith(req.path);
@@ -46,7 +47,8 @@ describe('PostController', () => {
     const res = mockResponse();
     await controller.post(req, res);
 
-    expect(req.session.userCase?.gender).toEqual(Gender.Female);
+    expect(req.session.userCase).toEqual({ divorceOrDissolution: 'divorce', gender: 'female', id: '1234' });
+    expect(req.locals.api.updateCase).toHaveBeenCalledWith('1234', { gender: 'female' });
 
     expect(getNextStepUrlMock).toBeCalledWith(req);
     expect(res.redirect).toBeCalledWith('/next-step-url');
@@ -54,7 +56,7 @@ describe('PostController', () => {
   });
 
   test('saves and signs out even if there are errors', async () => {
-    const errors = [{ field: 'field1', errorName: 'fail' }];
+    const errors = [{ field: 'gender', errorName: 'required' }];
     const body = { gender: Gender.Female, saveAndSignOut: true };
     const mockForm = ({
       getErrors: () => errors,
@@ -66,7 +68,8 @@ describe('PostController', () => {
     const res = mockResponse();
     await controller.post(req, res);
 
-    expect(req.session.userCase?.gender).toEqual(Gender.Female);
+    expect(req.session.userCase).toEqual({ divorceOrDissolution: 'divorce', gender: 'female', id: '1234' });
+    expect(req.locals.api.updateCase).toHaveBeenCalledWith('1234', { gender: 'female' });
 
     expect(res.redirect).toBeCalledWith(SAVE_SIGN_OUT_URL);
     expect(req.session.errors).toBe(undefined);

--- a/src/main/app/controller/PostController.test.ts
+++ b/src/main/app/controller/PostController.test.ts
@@ -14,7 +14,7 @@ const getNextStepUrlMock = getNextStepUrl as jest.Mock<string>;
 describe('PostController', () => {
   test('Should redirect back to the current page with the form data on errors', async () => {
     const errors = [{ field: 'field1', errorName: 'fail' }];
-    const body = { partnerGender: Gender.Female };
+    const body = { gender: Gender.Female };
     const mockForm = ({
       getErrors: () => errors,
       getParsedBody: () => body,
@@ -25,7 +25,7 @@ describe('PostController', () => {
     const res = mockResponse();
     await controller.post(req, res);
 
-    expect(req.session.userCase?.partnerGender).toEqual(Gender.Female);
+    expect(req.session.userCase?.gender).toEqual(Gender.Female);
 
     expect(getNextStepUrlMock).toBeCalledWith(req);
     expect(res.redirect).toBeCalledWith(req.path);
@@ -35,7 +35,7 @@ describe('PostController', () => {
   test('Should save the users data and redirect to the next page if the form is valid', async () => {
     getNextStepUrlMock.mockReturnValue('/next-step-url');
     const errors = [] as never[];
-    const body = { partnerGender: Gender.Female };
+    const body = { gender: Gender.Female };
     const mockForm = ({
       getErrors: () => errors,
       getParsedBody: () => body,
@@ -46,7 +46,7 @@ describe('PostController', () => {
     const res = mockResponse();
     await controller.post(req, res);
 
-    expect(req.session.userCase?.partnerGender).toEqual(Gender.Female);
+    expect(req.session.userCase?.gender).toEqual(Gender.Female);
 
     expect(getNextStepUrlMock).toBeCalledWith(req);
     expect(res.redirect).toBeCalledWith('/next-step-url');
@@ -55,7 +55,7 @@ describe('PostController', () => {
 
   test('saves and signs out even if there are errors', async () => {
     const errors = [{ field: 'field1', errorName: 'fail' }];
-    const body = { partnerGender: Gender.Female, saveAndSignOut: true };
+    const body = { gender: Gender.Female, saveAndSignOut: true };
     const mockForm = ({
       getErrors: () => errors,
       getParsedBody: () => body,
@@ -66,7 +66,7 @@ describe('PostController', () => {
     const res = mockResponse();
     await controller.post(req, res);
 
-    expect(req.session.userCase?.partnerGender).toEqual(Gender.Female);
+    expect(req.session.userCase?.gender).toEqual(Gender.Female);
 
     expect(res.redirect).toBeCalledWith(SAVE_SIGN_OUT_URL);
     expect(req.session.errors).toBe(undefined);
@@ -75,7 +75,7 @@ describe('PostController', () => {
   test('rejects with an error when unable to save session data', async () => {
     getNextStepUrlMock.mockReturnValue('/next-step-url');
     const errors = [] as never[];
-    const body = { partnerGender: Gender.Female };
+    const body = { gender: Gender.Female };
     const mockForm = ({
       getErrors: () => errors,
       getParsedBody: () => body,

--- a/src/main/app/controller/PostController.ts
+++ b/src/main/app/controller/PostController.ts
@@ -17,10 +17,9 @@ export class PostController<T extends AnyObject> {
    * redirect to.
    */
   public async post(req: AppRequest<T>, res: Response): Promise<void> {
-    const parsedBody = this.form.getParsedBody(req.body);
-    const { saveAndSignOut, _csrf, ...formData } = parsedBody;
+    const { saveAndSignOut, _csrf, ...formData } = this.form.getParsedBody(req.body);
 
-    const userCase = Object.assign(req.session.userCase, formData);
+    Object.assign(req.session.userCase, formData);
 
     const errors = this.form.getErrors(formData);
     const isSaveAndSignOut = !!req.body.saveAndSignOut;
@@ -29,7 +28,7 @@ export class PostController<T extends AnyObject> {
       req.session.errors = errors;
       nextUrl = req.url;
     } else {
-      await req.locals.api.updateCase(req.session.userCase?.id, userCase);
+      await req.locals.api.updateCase(req.session.userCase?.id, formData);
       req.session.errors = undefined;
     }
 

--- a/src/main/steps/index.test.ts
+++ b/src/main/steps/index.test.ts
@@ -15,7 +15,7 @@ describe('Steps', () => {
 
     it('returns the next step when correct details a passed', () => {
       mockReq.originalUrl = YOUR_DETAILS_URL;
-      mockReq.body = { partnerGender: Gender.Male };
+      mockReq.body = { gender: Gender.Male };
       expect(getNextStepUrl(mockReq)).toBe(HAS_RELATIONSHIP_BROKEN_URL);
     });
 
@@ -28,7 +28,7 @@ describe('Steps', () => {
 
     it('keeps the query string', () => {
       mockReq.originalUrl = `${YOUR_DETAILS_URL}?customQueryString`;
-      mockReq.body = { partnerGender: Gender.Male };
+      mockReq.body = { gender: Gender.Male };
       expect(getNextStepUrl(mockReq)).toBe(`${HAS_RELATIONSHIP_BROKEN_URL}?customQueryString`);
     });
   });
@@ -44,12 +44,12 @@ describe('Steps', () => {
     });
 
     it('returns the next incomplete step if previous is valid', () => {
-      mockReq.session.userCase.partnerGender = Gender.Male;
+      mockReq.session.userCase.gender = Gender.Male;
       expect(getNextIncompleteStepUrl(mockReq)).toBe(HAS_RELATIONSHIP_BROKEN_URL);
     });
 
     it('returns the previous step if its a dead end', () => {
-      mockReq.session.userCase.partnerGender = Gender.Male;
+      mockReq.session.userCase.gender = Gender.Male;
       mockReq.session.userCase.screenHasUnionBroken = YesOrNo.No;
       const actual = getNextIncompleteStepUrl(mockReq);
       expect(actual).toBe(HAS_RELATIONSHIP_BROKEN_URL);
@@ -57,7 +57,7 @@ describe('Steps', () => {
 
     it('keeps the query string', () => {
       mockReq.originalUrl = `${YOUR_DETAILS_URL}?customQueryString`;
-      mockReq.session.userCase.partnerGender = Gender.Male;
+      mockReq.session.userCase.gender = Gender.Male;
       expect(getNextIncompleteStepUrl(mockReq)).toBe(`${HAS_RELATIONSHIP_BROKEN_URL}?customQueryString`);
     });
   });

--- a/src/main/steps/sequence/check-answers/content.ts
+++ b/src/main/steps/sequence/check-answers/content.ts
@@ -7,7 +7,7 @@ export const generateContent: TranslationFn = ({ isDivorce, partner, formState }
     change: 'Change',
     yourDetails: `${isDivorce ? 'Who are you divorcing' : 'Are you male or female'}?`,
     yourDetailsA11y: 'Your details',
-    yourDetailsAnswer: `${isDivorce ? `My ${partner}` : formState.partnerGender}`,
+    yourDetailsAnswer: `${isDivorce ? `My ${partner}` : formState.gender}`,
     pay: 'Continue to payment',
   };
 

--- a/src/main/steps/sequence/your-details/content.ts
+++ b/src/main/steps/sequence/your-details/content.ts
@@ -12,7 +12,7 @@ export const generateContent: TranslationFn = ({ isDivorce }) => {
     sameSex: 'Select the following if it applies to you:',
     sameSexOption: `We were a same-sex couple when we ${isDivorce ? 'got married' : 'formed our civil partnership'}`,
     errors: {
-      partnerGender: {
+      gender: {
         required: commonContent.en.required,
       },
     },
@@ -22,7 +22,7 @@ export const generateContent: TranslationFn = ({ isDivorce }) => {
   const cy: typeof en = {
     ...en,
     errors: {
-      partnerGender: {
+      gender: {
         required: commonContent.cy.required,
       },
     },
@@ -37,7 +37,7 @@ export const generateContent: TranslationFn = ({ isDivorce }) => {
 
 export const form: FormContent = {
   fields: {
-    partnerGender: {
+    gender: {
       type: 'radios',
       classes: 'govuk-radios',
       label: l => l.title,

--- a/src/test/a11y/a11y.ts
+++ b/src/test/a11y/a11y.ts
@@ -72,6 +72,7 @@ describe('Accessibility', () => {
     }
 
     browser = await puppeteer.launch({ ignoreHTTPSErrors: true });
+    browser.on('disconnected', setup);
 
     // Login once only for other pages to reuse session
     const page = await browser.newPage();
@@ -81,8 +82,6 @@ describe('Accessibility', () => {
     await page.click('input[type="submit"]');
     cookies = await page.cookies(config.TEST_URL);
     await page.close();
-
-    browser.on('disconnected', setup);
   };
 
   beforeAll(setup);

--- a/src/test/functional/features/relationship-broken-down.feature
+++ b/src/test/functional/features/relationship-broken-down.feature
@@ -17,8 +17,7 @@ Feature: Relationship broken down
     Then the page should include "You cannot apply to get a divorce"
 
   Scenario: Selecting option for exit page for civil partnership
-    Given I go to '/?forceCivilMode'
-    And I go to '/irretrievable-breakdown?forceCivilMode'
+    Given I go to '/irretrievable-breakdown?forceCivilMode'
     When I select "No, my relationship has not irretrievably broken down"
     Then the page should include "This is the law in England and Wales."
     When I click "Continue"

--- a/src/test/functional/features/your-details-step.feature
+++ b/src/test/functional/features/your-details-step.feature
@@ -14,8 +14,7 @@ Feature: Your details step
     Then the page should include "Has your marriage irretrievably broken down (it cannot be saved)?"
 
   Scenario: Loading the your details for civil partnership
-    Given I go to '/?forceCivilMode'
-    And I go to '/your-details?forceCivilMode'
+    Given I go to '/your-details?forceCivilMode'
     Then I expect the page title to be "End a civil partnership - Are you male or female? - GOV.UK"
     And the page should include "Are you male or female?"
 


### PR DESCRIPTION
### Change description ###

Fixes the inferred petitioner/respondent gender when sending to the backend (based on the service type).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
