### PR TITLE
fix: checkbox deselection

### DIFF
--- a/src/main/app/case/case.ts
+++ b/src/main/app/case/case.ts
@@ -31,7 +31,7 @@ export type FieldFormats = Record<string, string | ((AnyObject) => AnyObject)>;
 export interface Case {
   divorceOrDissolution: CaseType;
   partnerGender?: Gender;
-  sameSex?: YesOrNo;
+  sameSex?: Checkbox;
   screenHasUnionBroken?: YesOrNo;
   relationshipDate?: CaseDate;
   hasCertificate?: YesOrNo;
@@ -58,6 +58,11 @@ export enum Gender {
 export enum YesOrNo {
   Yes = 'YES',
   No = 'NO',
+}
+
+export enum Checkbox {
+  Checked = 'checked',
+  Unchecked = '',
 }
 
 export interface CaseDate {

--- a/src/main/app/case/from-api-format.ts
+++ b/src/main/app/case/from-api-format.ts
@@ -1,12 +1,12 @@
 import { invert } from 'lodash';
 
 import { ApiCase } from './CaseApi';
-import { Case, YesOrNo, formFieldsToCaseMapping, formatCase } from './case';
+import { Case, Checkbox, YesOrNo, formFieldsToCaseMapping, formatCase } from './case';
 
 const fields = {
   ...invert(formFieldsToCaseMapping),
   D8MarriageIsSameSexCouple: data => ({
-    sameSex: data.D8MarriageIsSameSexCouple === YesOrNo.Yes ? 'checked' : '',
+    sameSex: data.D8MarriageIsSameSexCouple === YesOrNo.Yes ? Checkbox.Checked : Checkbox.Unchecked,
   }),
   D8MarriageDate: data => ({
     relationshipDate: fromApiDate(data.D8MarriageDate),

--- a/src/main/app/case/to-api-format.test.ts
+++ b/src/main/app/case/to-api-format.test.ts
@@ -1,10 +1,10 @@
 import { ApiCase } from './CaseApi';
-import { Gender, YesOrNo } from './case';
+import { Checkbox, Gender, YesOrNo } from './case';
 import { toApiFormat } from './to-api-format';
 
 describe('to-api-format', () => {
   const results = {
-    sameSex: 'checked',
+    sameSex: Checkbox.Checked,
     partnerGender: Gender.Male,
     relationshipDate: { year: '1900', month: '1', day: '4' },
     helpWithFeesRefNo: 'HWF-123-ABC',

--- a/src/main/app/case/to-api-format.ts
+++ b/src/main/app/case/to-api-format.ts
@@ -1,18 +1,18 @@
 import { isInvalidHelpWithFeesRef } from '../../app/form/validation';
 
 import { ApiCase } from './CaseApi';
-import { Case, CaseDate, Gender, YesOrNo, formFieldsToCaseMapping, formatCase } from './case';
+import { Case, CaseDate, Checkbox, Gender, YesOrNo, formFieldsToCaseMapping, formatCase } from './case';
 
 const fields = {
   ...formFieldsToCaseMapping,
   sameSex: data => ({
-    D8MarriageIsSameSexCouple: data.sameSex === 'checked' ? YesOrNo.Yes : YesOrNo.No,
+    D8MarriageIsSameSexCouple: data.sameSex === Checkbox.Checked ? YesOrNo.Yes : YesOrNo.No,
   }),
   partnerGender: data => ({
     D8InferredRespondentGender: data.partnerGender,
     D8InferredPetitionerGender:
-      (data.partnerGender === Gender.Male && data.sameSex === 'checked') ||
-      (data.partnerGender === Gender.Female && data.sameSex !== 'checked')
+      (data.partnerGender === Gender.Male && data.sameSex === Checkbox.Checked) ||
+      (data.partnerGender === Gender.Female && data.sameSex !== Checkbox.Checked)
         ? Gender.Male
         : Gender.Female,
   }),

--- a/src/main/app/controller/PostController.test.ts
+++ b/src/main/app/controller/PostController.test.ts
@@ -1,9 +1,9 @@
 import { mockRequest } from '../../../test/unit/utils/mockRequest';
 import { mockResponse } from '../../../test/unit/utils/mockResponse';
-import { Form } from '../../app/form/Form';
+import { Form, FormContent } from '../../app/form/Form';
 import { getNextStepUrl } from '../../steps';
 import { SAVE_SIGN_OUT_URL } from '../../steps/urls';
-import { Gender } from '../case/case';
+import { Checkbox, Gender } from '../case/case';
 
 import { PostController } from './PostController';
 
@@ -91,5 +91,24 @@ describe('PostController', () => {
     expect(getNextStepUrlMock).toBeCalledWith(req);
     expect(res.redirect).not.toHaveBeenCalled();
     expect(req.session.errors).toBe(undefined);
+  });
+
+  test('uses the last (not hidden) input for checkboxes', async () => {
+    getNextStepUrlMock.mockReturnValue('/next-step-url');
+    const body = { sameSex: [0, Checkbox.Checked] };
+    const mockFormContent = ({
+      fields: {
+        sameSex: {
+          type: 'checkboxes',
+        },
+      },
+    } as unknown) as FormContent;
+    const controller = new PostController(new Form(mockFormContent));
+
+    const req = mockRequest({ body });
+    const res = mockResponse();
+    await controller.post(req, res);
+
+    expect(req.session.userCase?.sameSex).toEqual(Checkbox.Checked);
   });
 });

--- a/src/main/app/controller/PostController.ts
+++ b/src/main/app/controller/PostController.ts
@@ -1,7 +1,6 @@
 import autobind from 'autobind-decorator';
 import { Response } from 'express';
 
-import { CaseWithId } from '../../app/case/case';
 import { getNextStepUrl } from '../../steps';
 import { SAVE_SIGN_OUT_URL } from '../../steps/urls';
 import { Form } from '../form/Form';
@@ -18,7 +17,7 @@ export class PostController<T extends AnyObject> {
    * redirect to.
    */
   public async post(req: AppRequest<T>, res: Response): Promise<void> {
-    const parsedBody = this.form.getParsedBody(req.body) as CaseWithFormData;
+    const parsedBody = this.form.getParsedBody(req.body);
     const { saveAndSignOut, _csrf, ...formData } = parsedBody;
 
     const userCase = Object.assign(req.session.userCase, formData);
@@ -44,8 +43,3 @@ export class PostController<T extends AnyObject> {
 }
 
 export type AnyObject = Record<string, unknown>;
-
-interface CaseWithFormData extends CaseWithId {
-  _csrf: string;
-  saveAndSignOut?: string;
-}

--- a/src/main/app/form/Form.test.ts
+++ b/src/main/app/form/Form.test.ts
@@ -126,9 +126,8 @@ describe('Form', () => {
       'dateField-month': '1',
       'dateField-year': '2000',
     };
-    form.getParsedBody(body);
 
-    expect(body).toStrictEqual({
+    expect(form.getParsedBody(body)).toStrictEqual({
       field: 'YES',
       dateField: {
         day: '1',

--- a/src/main/app/form/Form.ts
+++ b/src/main/app/form/Form.ts
@@ -1,4 +1,4 @@
-import { Case, CaseDate } from '../case/case';
+import { CaseDate, CaseWithId } from '../case/case';
 import { AnyObject } from '../controller/PostController';
 
 export class Form {
@@ -7,7 +7,7 @@ export class Form {
   /**
    * Pass the form body to any fields with a parser and return mutated body;
    */
-  public getParsedBody(body: AnyObject): Partial<Case> {
+  public getParsedBody(body: AnyObject): Partial<CaseWithFormData> {
     const parsedBody = Object.entries(this.form.fields)
       .map(([key, field]) => {
         if ((field as FormOptions)?.type === 'checkboxes') {
@@ -28,7 +28,7 @@ export class Form {
   /**
    * Pass the form body to any fields with a validator and return a list of errors
    */
-  public getErrors(body: Partial<Case>, fields = this.form?.fields): FormError[] {
+  public getErrors(body: Partial<CaseWithFormData>, fields = this.form?.fields): FormError[] {
     if (!fields) {
       return [];
     }
@@ -107,3 +107,8 @@ export type FormError = {
   propertyName: string;
   errorType: string;
 };
+
+interface CaseWithFormData extends CaseWithId {
+  _csrf: string;
+  saveAndSignOut?: string;
+}

--- a/src/main/app/form/parser.test.ts
+++ b/src/main/app/form/parser.test.ts
@@ -6,17 +6,12 @@ describe('Parser', () => {
       'date-day': '1',
       'date-month': '1',
       'date-year': '1',
-      'additional-property': 'for additional element on the page',
     };
-    covertToDateObject('date', date);
 
-    expect(date).toStrictEqual({
-      date: {
-        day: '1',
-        month: '1',
-        year: '1',
-      },
-      'additional-property': 'for additional element on the page',
+    expect(covertToDateObject('date', date)).toStrictEqual({
+      day: '1',
+      month: '1',
+      year: '1',
     });
   });
 });

--- a/src/main/app/form/parser.ts
+++ b/src/main/app/form/parser.ts
@@ -1,11 +1,14 @@
-export type Parser = (property: string, body: Record<string, unknown>) => void;
+import { CaseDate } from '../../app/case/case';
 
-export const covertToDateObject: Parser = (property, body) => {
-  const dateObject = ['day', 'month', 'year'].reduce((newDateObj: string | Record<string, string>, date: string) => {
-    const propertyName = `${property}-${date}`;
-    newDateObj[date] = body[propertyName];
-    delete body[propertyName];
-    return newDateObj;
-  }, {});
-  body[property] = dateObject;
-};
+export type DateParser = (property: string, body: Record<string, unknown>) => CaseDate;
+
+export const covertToDateObject: DateParser = (property, body) =>
+  ['day', 'month', 'year'].reduce(
+    (newDateObj: CaseDate, date: string) => {
+      const propertyName = `${property}-${date}`;
+      newDateObj[date] = body[propertyName];
+      delete body[propertyName];
+      return newDateObj;
+    },
+    { year: '', month: '', day: '' }
+  );

--- a/src/main/steps/common/form/fields.njk
+++ b/src/main/steps/common/form/fields.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
 {% for fieldName, field in form.fields %}
   {% switch field.type %}
@@ -19,6 +20,9 @@
           items: formItems(field.values, formState[fieldName])
         }) }}
     {% case 'checkboxes' %}
+      {# Required for sending an empty value when the checkbox has not been checked #}
+      <input type="hidden" value="" name="{{ fieldName }}">
+
       {{ govukCheckboxes({
         classes: field.classes,
         idPrefix: fieldName,

--- a/src/main/steps/common/form/form.njk
+++ b/src/main/steps/common/form/form.njk
@@ -1,9 +1,4 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/select/macro.njk" import govukSelect %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
 <form class="form" id="main-form" method="post" action="" novalidate="novalidate">
   <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/src/main/steps/sequence/your-details/content.ts
+++ b/src/main/steps/sequence/your-details/content.ts
@@ -1,4 +1,4 @@
-import { Gender } from '../../../app/case/case';
+import { Checkbox, Gender } from '../../../app/case/case';
 import { TranslationFn } from '../../../app/controller/GetController';
 import { FormContent } from '../../../app/form/Form';
 import { isFieldFilledIn } from '../../../app/form/validation';
@@ -50,7 +50,7 @@ export const form: FormContent = {
     sameSex: {
       type: 'checkboxes',
       label: l => l.sameSex,
-      values: [{ label: l => l.sameSexOption, value: 'checked' }],
+      values: [{ label: l => l.sameSexOption, value: Checkbox.Checked }],
     },
   },
   submit: {

--- a/src/test/tsconfig.json
+++ b/src/test/tsconfig.json
@@ -4,7 +4,7 @@
   },
   "compilerOptions": {
     "target": "es2018",
-    "lib": ["es2018", "DOM", "dom.iterable"],
+    "lib": ["es2019", "dom", "dom.iterable"],
     "esModuleInterop": true,
     "module": "commonjs",
     "strictNullChecks": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "experimentalDecorators": true,
     "skipLibCheck": true,
-    "lib": ["es6", "es2017.object", "dom", "dom.iterable"],
+    "lib": ["es2019", "dom", "dom.iterable"],
     "baseUrl": "src/main",
     "paths": {
       "router/*": ["router/*"],


### PR DESCRIPTION
### Change description ###

Currently ticking a checkbox and continuing and then going back and deselecting a checkbox fails to update the `userCase`.

This PR will set a default value for checkboxes as an empty string (via a hidden field) and use a parser for checkboxes to return the correct result.

This also changes field parsers to be non-mutating.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
