### PR TITLE
fix: sign in again link on error pages to trigger a logout

### DIFF
--- a/src/main/steps/error/error.njk
+++ b/src/main/steps/error/error.njk
@@ -7,7 +7,7 @@
   <ul class="govuk-list govuk-list--bullet">
     <li>{{ goBack }}</li>
     <li>
-      <a class="govuk-link" href="/">{{ signInAgain }}</a>
+      <a class="govuk-link" href="/logout">{{ signInAgain }}</a>
     </li>
   </ul>
 {% endblock %}


### PR DESCRIPTION
### Change description ###

Login in to the civil partnership dissolution app with a user that has already started completing the application using the divorce app. An error page is shown, however the "Sign in again" link doesn't trigger a logout so the user is not redirected to the login page. This PR triggers a logout first.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
