### PR TITLE
fix: save & sign out get controller

### DIFF
--- a/src/main/app/controller/GetController.ts
+++ b/src/main/app/controller/GetController.ts
@@ -24,7 +24,11 @@ export type TranslationFn = ({
 
 @autobind
 export class GetController {
-  constructor(protected readonly view: string, protected readonly content: TranslationFn | Translations) {}
+  constructor(
+    protected readonly view: string,
+    protected readonly content: TranslationFn | Translations,
+    protected language = 'en'
+  ) {}
 
   public async get(req: AppRequest, res: Response): Promise<void> {
     if (res.locals.isError || res.headersSent) {

--- a/src/main/app/controller/GetController.ts
+++ b/src/main/app/controller/GetController.ts
@@ -24,11 +24,7 @@ export type TranslationFn = ({
 
 @autobind
 export class GetController {
-  constructor(
-    protected readonly view: string,
-    protected readonly content: TranslationFn | Translations,
-    protected language = 'en'
-  ) {}
+  constructor(protected readonly view: string, protected readonly content: TranslationFn | Translations) {}
 
   public async get(req: AppRequest, res: Response): Promise<void> {
     if (res.locals.isError || res.headersSent) {
@@ -46,7 +42,7 @@ export class GetController {
     const partner = this.getPartnerContent(selectedGender, isDivorce, commonLanguageContent);
     const content = this.getContent(isDivorce, partner, formState);
 
-    const languageContent = content[this.language];
+    const languageContent = content[language];
     const commonPageContent = content.common || {};
     const sessionErrors = req.session?.errors || [];
 

--- a/src/main/app/controller/GetController.ts
+++ b/src/main/app/controller/GetController.ts
@@ -46,7 +46,7 @@ export class GetController {
     const partner = this.getPartnerContent(selectedGender, isDivorce, commonLanguageContent);
     const content = this.getContent(isDivorce, partner, formState);
 
-    const languageContent = content[language];
+    const languageContent = content[this.language];
     const commonPageContent = content.common || {};
     const sessionErrors = req.session?.errors || [];
 

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -2,17 +2,17 @@ import fs from 'fs';
 
 import { Application, RequestHandler, Response } from 'express';
 
-import { AppRequest } from '../main/app/controller/AppRequest';
-import { GetController } from '../main/app/controller/GetController';
-import { AnyObject, PostController } from '../main/app/controller/PostController';
-import { Form } from '../main/app/form/Form';
-import { SaveSignOutPostController } from '../main/steps/save-sign-out/post';
-
+import { AppRequest } from './app/controller/AppRequest';
+import { GetController } from './app/controller/GetController';
+import { AnyObject, PostController } from './app/controller/PostController';
+import { Form } from './app/form/Form';
 import { AccessibilityStatementGetController } from './steps/accessibility-statement/get';
 import { CookiesGetController } from './steps/cookies/get';
 import { ErrorController } from './steps/error/error.controller';
 import { HomeGetController } from './steps/home/get';
 import { PrivacyPolicyGetController } from './steps/privacy-policy/get';
+import { SaveSignOutGetController } from './steps/save-sign-out/get';
+import { SaveSignOutPostController } from './steps/save-sign-out/post';
 import { sequence } from './steps/sequence';
 import { TermsAndConditionsGetController } from './steps/terms-and-conditions/get';
 import { TimedOutGetController } from './steps/timed-out/get';
@@ -22,6 +22,7 @@ import {
   CSRF_TOKEN_ERROR_URL,
   HOME_URL,
   PRIVACY_POLICY_URL,
+  SAVE_AND_SIGN_OUT,
   SIGN_OUT_URL,
   TERMS_AND_CONDITIONS_URL,
   TIMED_OUT_URL,
@@ -34,6 +35,7 @@ export class Routes {
 
     app.get(CSRF_TOKEN_ERROR_URL, errorHandler(errorController.CSRFTokenError));
     app.get(HOME_URL, errorHandler(new HomeGetController().get));
+    app.get(SAVE_AND_SIGN_OUT, errorHandler(new SaveSignOutGetController().get));
     app.get(TIMED_OUT_URL, errorHandler(new TimedOutGetController().get));
     app.get(PRIVACY_POLICY_URL, errorHandler(new PrivacyPolicyGetController().get));
     app.get(TERMS_AND_CONDITIONS_URL, errorHandler(new TermsAndConditionsGetController().get));

--- a/src/main/steps/apply-for-help-with-fees/template.njk
+++ b/src/main/steps/apply-for-help-with-fees/template.njk
@@ -5,5 +5,5 @@
   <p class="govuk-body">{{ line1 | safe }}</p>
   <p class="govuk-body govuk-inset-text">{{ line2 | safe }}</p>
   <p class="govuk-body">{{ line3 }}</p>
-  <p class="govuk-body"><a href="/save-and-sign-out" class="govuk-link">{{ saveAndSignOut }}</a></p>
+  <p class="govuk-body"><a href="/save-and-sign-out?lng={{language}}" class="govuk-link">{{ saveAndSignOut }}</a></p>
 {% endblock %}

--- a/src/main/steps/get-certified-translation/template.njk
+++ b/src/main/steps/get-certified-translation/template.njk
@@ -6,5 +6,5 @@
   <p class="govuk-body"> {{ line2 }}</p>
   <h3 class="govuk-heading-m">{{ subHeading }}</h3>
   <p class="govuk-body"> {{ line3 | safe }}</p>
-  <p class="govuk-body"><a href="/save-and-sign-out" class="govuk-link">{{ saveAndSignOut }}</a></p>
+  <p class="govuk-body"><a href="/save-and-sign-out?lng={{language}}" class="govuk-link">{{ saveAndSignOut }}</a></p>
 {% endblock %}

--- a/src/main/steps/save-sign-out/get.test.ts
+++ b/src/main/steps/save-sign-out/get.test.ts
@@ -1,0 +1,23 @@
+import { defaultViewArgs } from '../../../test/unit/utils/defaultViewArgs';
+import { mockRequest } from '../../../test/unit/utils/mockRequest';
+import { mockResponse } from '../../../test/unit/utils/mockResponse';
+import { saveAndSignOutContent } from '../../steps/save-sign-out/content';
+
+import { SaveSignOutGetController } from './get';
+
+describe('SaveSignOutGetController', () => {
+  it('saves and signs out', async () => {
+    const controller = new SaveSignOutGetController();
+
+    const req = mockRequest({ session: { user: { email: 'test@example.com' } } });
+    const res = mockResponse();
+    await controller.get(req, res);
+
+    expect(req.session.destroy).toHaveBeenCalled();
+    expect(res.render).toHaveBeenCalledWith(`${__dirname}/template`, {
+      ...defaultViewArgs,
+      ...saveAndSignOutContent['en'],
+      email: 'test@example.com',
+    });
+  });
+});

--- a/src/main/steps/save-sign-out/get.ts
+++ b/src/main/steps/save-sign-out/get.ts
@@ -14,10 +14,6 @@ export class SaveSignOutGetController extends GetController {
   public async get(req: AppRequest, res: Response): Promise<void> {
     this.content['common']['email'] = req.session.user?.email;
 
-    if (req.session?.lang) {
-      this.language = req.session.lang;
-    }
-
     req.session.destroy(err => {
       if (err) {
         throw err;

--- a/src/main/steps/save-sign-out/get.ts
+++ b/src/main/steps/save-sign-out/get.ts
@@ -1,0 +1,29 @@
+import autobind from 'autobind-decorator';
+import { Response } from 'express';
+
+import { AppRequest } from '../../app/controller/AppRequest';
+import { GetController } from '../../app/controller/GetController';
+import { saveAndSignOutContent } from '../../steps/save-sign-out/content';
+
+@autobind
+export class SaveSignOutGetController extends GetController {
+  constructor() {
+    super(__dirname + '/template', saveAndSignOutContent);
+  }
+
+  public async get(req: AppRequest, res: Response): Promise<void> {
+    this.content['common']['email'] = req.session.user?.email;
+
+    if (req.session?.lang) {
+      this.language = req.session.lang;
+    }
+
+    req.session.destroy(err => {
+      if (err) {
+        throw err;
+      }
+
+      super.get(req, res);
+    });
+  }
+}

--- a/src/main/steps/save-sign-out/post.test.ts
+++ b/src/main/steps/save-sign-out/post.test.ts
@@ -27,7 +27,7 @@ describe('SaveSignOutPostController', () => {
 
     expect(req.session.errors).toBe(undefined);
     expect(req.session.destroy).toHaveBeenCalled();
-    expect(res.render).toHaveBeenCalledWith(`${__dirname}/../../steps/save-sign-out/template.njk`, {
+    expect(res.render).toHaveBeenCalledWith(`${__dirname}/template`, {
       ...commonContent['en'],
       ...saveAndSignOutContent['en'],
       email: 'test@example.com',

--- a/src/main/steps/save-sign-out/post.ts
+++ b/src/main/steps/save-sign-out/post.ts
@@ -24,7 +24,7 @@ export class SaveSignOutPostController<T extends AnyObject> extends PostControll
         throw err;
       }
 
-      res.render(`${__dirname}/../../steps/save-sign-out/template.njk`, {
+      res.render(`${__dirname}/template`, {
         ...commonContent[language],
         ...saveAndSignOutContent[language],
         email,

--- a/src/main/steps/urls.ts
+++ b/src/main/steps/urls.ts
@@ -3,6 +3,7 @@ export type PageLink = `/${string}`;
 export const HOME_URL: PageLink = '/';
 export const SIGN_IN_URL: PageLink = '/login';
 export const SIGN_OUT_URL: PageLink = '/logout';
+export const SAVE_AND_SIGN_OUT: PageLink = '/save-and-sign-out';
 export const TIMED_OUT_URL: PageLink = '/timed-out';
 export const CSRF_TOKEN_ERROR_URL: PageLink = '/csrf-token-error';
 export const PRIVACY_POLICY_URL: PageLink = '/privacy-policy';

--- a/src/main/steps/you-need-your-certificate/template.njk
+++ b/src/main/steps/you-need-your-certificate/template.njk
@@ -5,5 +5,5 @@
   <p class="govuk-body">{{ line1 }}</p>
   <p class="govuk-body"> {{ line2 | safe }}</p>
   <p class="govuk-body"> {{ line3 | safe }}</p>
-  <p class="govuk-body"><a href="/save-and-sign-out" class="govuk-link">{{ saveAndSignOut }}</a></p>
+  <p class="govuk-body"><a href="/save-and-sign-out?lng={{language}}" class="govuk-link">{{ saveAndSignOut }}</a></p>
 {% endblock %}


### PR DESCRIPTION
### Change description ###

Some exit pages/dead ends where using a "Save and sign out" link which was moved to a post controller.

This PR fixes a 404 error with the "Save and sign out" link/request by adding the missing get controller.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
