### PR TITLE
moving the getPartner method to get common content

### DIFF
--- a/src/main/app/controller/GetController.ts
+++ b/src/main/app/controller/GetController.ts
@@ -3,7 +3,7 @@ import autobind from 'autobind-decorator';
 import { Response } from 'express';
 
 import { getNextIncompleteStepUrl } from '../../steps';
-import { commonContent } from '../../steps/common/common.content';
+import { generateCommonContent } from '../../steps/common/common.content';
 import { Case } from '../case/case';
 
 import { AppRequest } from './AppRequest';
@@ -32,12 +32,11 @@ export class GetController {
     }
 
     const language = req.session?.lang || 'en';
-    const commonLanguageContent = commonContent[language];
 
     const isDivorce = res.locals.serviceType === DivorceOrDissolution.DIVORCE;
     const formState = req.session?.userCase;
     const selectedGender = formState?.gender as Gender;
-    const partner = this.getPartnerContent(selectedGender, isDivorce, commonLanguageContent);
+    const { commonTranslations, partner } = generateCommonContent({ language, isDivorce, selectedGender });
     const content = this.getContent(isDivorce, partner, formState);
 
     const languageContent = content[language];
@@ -49,7 +48,7 @@ export class GetController {
     }
 
     res.render(this.view, {
-      ...commonLanguageContent,
+      ...commonTranslations,
       ...languageContent,
       ...commonPageContent,
       sessionErrors,
@@ -71,20 +70,5 @@ export class GetController {
       partner,
       formState,
     });
-  }
-
-  private getPartnerContent(selectedGender: Gender, isDivorce: boolean, translations: Translations): string {
-    if (!isDivorce) {
-      return translations['civilPartner'];
-    }
-
-    if (selectedGender === Gender.MALE) {
-      return translations['husband'];
-    }
-    if (selectedGender === Gender.FEMALE) {
-      return translations['wife'];
-    }
-
-    return translations['partner'];
   }
 }

--- a/src/main/steps/common/common.content.ts
+++ b/src/main/steps/common/common.content.ts
@@ -1,3 +1,5 @@
+import { Gender } from '@hmcts/nfdiv-case-definition';
+
 const en = {
   phase: 'Beta',
   feedback:
@@ -145,6 +147,33 @@ const cy: typeof en = {
   },
   yes: 'Do',
   no: 'Naddo',
+};
+
+export const generateCommonContent = ({
+  language,
+  isDivorce,
+  selectedGender,
+}: {
+  language: string;
+  isDivorce: boolean;
+  selectedGender: string;
+}): { commonTranslations: Record<string, unknown>; partner: string } => {
+  const commonTranslations = language === 'en' ? en : cy;
+  let partner;
+  if (!isDivorce) {
+    partner = commonTranslations['civilPartner'];
+  } else if (selectedGender === Gender.MALE) {
+    partner = commonTranslations['husband'];
+  } else if (selectedGender === Gender.FEMALE) {
+    partner = commonTranslations['wife'];
+  } else {
+    partner = commonTranslations['partner'];
+  }
+
+  return {
+    commonTranslations,
+    partner,
+  };
 };
 
 export const commonContent = { en, cy };


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/NFDIV-514


### Change description ###
moved the get partner to common content.
tried to make all of common content a function but it doesnt work considering multiple factors such as knowing which translations to use, also still export the english and welsh objects as its used throughout the project, have an example of how it looks if i done in [nfdiv-514-example](https://github.com/hmcts/nfdiv-frontend/compare/nfdiv-514...nfdiv-514-example) 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
