### PR TITLE
feat(NFDIV-487): Allow users to have one divorce & one civil dissolution case

### DIFF
--- a/src/main/app/case/CaseApi.test.ts
+++ b/src/main/app/case/CaseApi.test.ts
@@ -27,22 +27,31 @@ describe('CaseApi', () => {
 
   const serviceType = DivorceOrDissolution.DIVORCE;
 
-  test('Should return case data response', async () => {
-    mockedAxios.get.mockResolvedValue({
-      data: [
-        {
-          id: '1234',
-          case_data: {
-            divorceOrDissolution: 'divorce',
+  test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
+    'Should return %s case data response',
+    async caseType => {
+      mockedAxios.get.mockResolvedValue({
+        data: [
+          {
+            id: '1234',
+            case_data: {
+              divorceOrDissolution: 'divorce',
+            },
           },
-        },
-      ],
-    });
+          {
+            id: '1234',
+            case_data: {
+              divorceOrDissolution: 'dissolution',
+            },
+          },
+        ],
+      });
 
-    const userCase = await api.getOrCreateCase(serviceType, userDetails);
+      const userCase = await api.getOrCreateCase(caseType, userDetails);
 
-    expect(userCase).toStrictEqual({ id: '1234', divorceOrDissolution: 'divorce' });
-  });
+      expect(userCase).toStrictEqual({ id: '1234', divorceOrDissolution: caseType });
+    }
+  );
 
   test('Should throw error when case could not be retrieved', async () => {
     mockedAxios.get.mockRejectedValue({
@@ -88,8 +97,10 @@ describe('CaseApi', () => {
   });
 
   test('Should throw an error if too many cases are found', async () => {
+    const mockCase = { case_data: { divorceOrDissolution: serviceType } };
+
     mockedAxios.get.mockResolvedValue({
-      data: [{}, {}],
+      data: [mockCase, mockCase],
     });
 
     await expect(api.getOrCreateCase(serviceType, userDetails)).rejects.toThrow('Too many cases assigned to user.');

--- a/src/main/app/case/CaseApi.ts
+++ b/src/main/app/case/CaseApi.ts
@@ -18,20 +18,22 @@ export class CaseApi {
   ) {}
 
   public async getOrCreateCase(serviceType: DivorceOrDissolution, userDetails: UserDetails): Promise<CaseWithId> {
-    const userCase = await this.getCase();
+    const userCase = await this.getCase(serviceType);
 
     return userCase || this.createCase(serviceType, userDetails);
   }
 
-  private async getCase(): Promise<CaseWithId | false> {
+  private async getCase(serviceType: DivorceOrDissolution): Promise<CaseWithId | false> {
     const cases = await this.getCases();
 
-    if (cases.length === 1) {
-      return { id: cases[0].id, ...fromApiFormat(cases[0].case_data) };
-    } else if (cases.length === 0) {
-      return false;
-    } else {
-      throw new Error('Too many cases assigned to user.');
+    const serviceCases = cases.filter(c => c.case_data.divorceOrDissolution === serviceType);
+    switch (serviceCases.length) {
+      case 0:
+        return false;
+      case 1:
+        return { id: serviceCases[0].id, ...fromApiFormat(serviceCases[0].case_data) };
+      default:
+        throw new Error('Too many cases assigned to user.');
     }
   }
 


### PR DESCRIPTION
### JIRA link ###

[NFDIV-487](https://tools.hmcts.net/jira/browse/NFDIV-487) Switching between a divorce and civil dissolution case type

### Change description ###

Users should be allowed to have one of each case type.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
