### PR TITLE
fix: handle triggerEvent errors on sign out

### DIFF
--- a/src/main/app/controller/PostController.ts
+++ b/src/main/app/controller/PostController.ts
@@ -31,15 +31,19 @@ export class PostController<T extends AnyObject> {
 
   private async saveAndSignOut(req: AppRequest<T>, res: Response, formData: Partial<Case>): Promise<void> {
     try {
-      this.save(req, formData, SAVE_AND_CLOSE);
-    } finally {
-      res.redirect(SAVE_AND_SIGN_OUT);
+      await this.save(req, formData, SAVE_AND_CLOSE);
+    } catch {
+      // ignore
     }
+    res.redirect(SAVE_AND_SIGN_OUT);
   }
 
   private async saveBeforeSessionTimeout(req: AppRequest<T>, res: Response, formData: Partial<Case>): Promise<void> {
-    await this.save(req, formData, PATCH_CASE);
-
+    try {
+      await this.save(req, formData, PATCH_CASE);
+    } catch {
+      // ignore
+    }
     res.end();
   }
 
@@ -50,7 +54,7 @@ export class PostController<T extends AnyObject> {
     if (req.session.errors.length === 0) {
       try {
         req.session.userCase = await this.save(req, formData, PATCH_CASE);
-      } catch (err) {
+      } catch {
         req.session.errors.push({ errorType: 'errorSaving', propertyName: '*' });
       }
     }


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

Fixed error from API when trying to sign out.

A `try` without a `catch` clause sends its error to the next higher catch, or the window, if there is no catch defined within that try.

So for example this will still throw an error:

```ts
try {
  throw new Error('💥');
} finally {
  allwaysDoThis();
}
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
