### PR TITLE
chore: set @typescript-eslint/no-shadow to error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'error',
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-non-null-assertion': 'error',
+    '@typescript-eslint/no-shadow': 'error',
     '@typescript-eslint/no-unused-vars': [
       'error',
       {

--- a/src/main/app/case/answers/getAnswerRows.ts
+++ b/src/main/app/case/answers/getAnswerRows.ts
@@ -96,7 +96,7 @@ const getCheckedLabels = (answer, field, stepContent) => {
   const checkedLabels = answer
     .filter(([, value]) => value === Checkbox.Checked)
     .map(([key]) => {
-      const checkbox = field.values.find(field => field.name === key);
+      const checkbox = field.values.find(checkboxField => checkboxField.name === key);
       if (typeof checkbox?.label === 'function') {
         return checkbox.label(stepContent);
       }

--- a/src/main/app/case/answers/possibleAnswers.ts
+++ b/src/main/app/case/answers/possibleAnswers.ts
@@ -31,7 +31,7 @@ export const getAllPossibleAnswers = (caseState: Partial<Case>, steps: Step[]): 
     }
 
     const nextStepUrl = step.getNextStep(caseState);
-    const nextStep = sequenceWithForms.find(step => step.url === nextStepUrl);
+    const nextStep = sequenceWithForms.find(sequenceStep => sequenceStep.url === nextStepUrl);
     if (nextStep) {
       return getPossibleFields(nextStep, fields);
     }

--- a/src/main/app/form/Form.ts
+++ b/src/main/app/form/Form.ts
@@ -31,11 +31,11 @@ export class Form {
 
     const errors = Object.keys(fields)
       .filter(key => fields[key].validator !== undefined)
-      .reduce((errors: FormError[], propertyName: string) => {
+      .reduce((formErrors: FormError[], propertyName: string) => {
         const field = <FormField & { validator: ValidationCheck }>fields[propertyName];
         const errorType = field.validator(body?.[propertyName] as string);
 
-        return errorType ? errors.concat({ errorType, propertyName }) : errors;
+        return errorType ? formErrors.concat({ errorType, propertyName }) : formErrors;
       }, []);
 
     const checkboxErrors: FormError[] = [];


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

Sets [@typescript-eslint/no-shadow](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md) to `error` and fixes existing errors that were reported.

This disallows variable declarations from shadowing variables names declared in the outer scope.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
