### PR TITLE
chore: handle multiple errors being caught

### DIFF
--- a/src/main/steps/error/error.controller.test.ts
+++ b/src/main/steps/error/error.controller.test.ts
@@ -82,6 +82,24 @@ describe('ErrorController', () => {
       ...errorContent.en[400],
     });
   });
+
+  test('Only calls res.render() once when multiple errors have been caught', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    controller.internalServerError(undefined, req, res);
+    controller.internalServerError(undefined, req, res);
+    controller.internalServerError(undefined, req, res);
+    const logger = (req.locals.logger as unknown) as MockedLogger;
+
+    expect(logger.error).toHaveBeenCalledTimes(3);
+    expect(logger.error.mock.calls[0][0]).toBe('Internal Server Error');
+    expect(res.statusCode).toBe(500);
+    expect(res.render).toHaveBeenCalledTimes(1);
+    expect(res.render).toBeCalledWith('error/error', {
+      ...generatePageContent({ language: 'en', userEmail: 'test@example.com' }),
+      ...errorContent.en[500],
+    });
+  });
 });
 
 interface MockedLogger {


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

In some cases multiple errors are thrown and caught, in these cases the application was crashing due to headers already sent.

This PR checks if HTTP headers have already been sent before trying to render.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
