### PR TITLE
fix: handlle missing session data when service-auth-token errors

### DIFF
--- a/src/main/steps/common/common.content.ts
+++ b/src/main/steps/common/common.content.ts
@@ -166,7 +166,7 @@ export const generatePageContent = ({
   pageContent?: TranslationFn;
   isDivorce?: boolean;
   formState?: Partial<Case>;
-  userEmail: string;
+  userEmail?: string;
 }): PageContent => {
   const commonTranslations: typeof en = language === 'en' ? en : cy;
   const serviceName = getServiceName(commonTranslations, isDivorce);

--- a/src/main/steps/error/error.controller.ts
+++ b/src/main/steps/error/error.controller.ts
@@ -57,7 +57,7 @@ export class ErrorController {
     const language = (req.session?.lang || 'en') as Language;
     const errorText =
       errorContent[language][res.statusCode] || errorContent[language][StatusCodes.INTERNAL_SERVER_ERROR];
-    const commonContent = generatePageContent({ language, userEmail: req.session?.user.email });
+    const commonContent = generatePageContent({ language, userEmail: req.session?.user?.email });
     res.locals.isError = true;
 
     res.status(res.statusCode || StatusCodes.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

Handles case were session is set, but fails to fetch user/userCase e.g. because of an service-auth-token error, or network error etc.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
