### PR TITLE
chore: auto create/delete IDAM test users for functional tests

### DIFF
--- a/src/test/cross-browser/codecept.conf.ts
+++ b/src/test/cross-browser/codecept.conf.ts
@@ -48,6 +48,7 @@ if (process.env.SAUCE === 'true') {
 }
 
 export const config: CodeceptJS.Config = {
+  name: 'nfdiv-frontend-cross-browser',
   gherkin: testConfig.Gherkin,
   output: '../../../functional-output/crossbrowser/reports',
   helpers,
@@ -59,8 +60,8 @@ export const config: CodeceptJS.Config = {
       browsers: [{ browser: 'chromium' }, { browser: 'webkit' }, { browser: 'firefox' }],
     },
   },
-  bootstrap: null,
-  name: 'nfdiv-frontend',
+  bootstrap: testConfig.bootstrap,
+  teardown: testConfig.teardown,
   plugins: {
     autoLogin: testConfig.AutoLogin,
     allure: {

--- a/src/test/functional/codecept.conf.ts
+++ b/src/test/functional/codecept.conf.ts
@@ -5,6 +5,7 @@ import { config as testConfig } from '../config';
 setHeadlessWhen(testConfig.TestHeadlessBrowser);
 
 export const config: CodeceptJS.Config = {
+  name: 'nfdiv-frontend-functional',
   gherkin: testConfig.Gherkin,
   output: '../../../functional-output/functional/reports',
   helpers: {
@@ -18,8 +19,8 @@ export const config: CodeceptJS.Config = {
       ignoreHTTPSErrors: true,
     },
   },
-  bootstrap: null,
-  name: 'nfdiv-frontend',
+  bootstrap: testConfig.bootstrap,
+  teardown: testConfig.teardown,
   plugins: {
     autoLogin: testConfig.AutoLogin,
     allure: {

--- a/src/test/steps/IdamUserManager.ts
+++ b/src/test/steps/IdamUserManager.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+
+import axios, { AxiosInstance } from 'axios';
+
+export class IdamUserManager {
+  client: AxiosInstance;
+
+  constructor(
+    idamUrl: string,
+    private readonly email: string,
+    private readonly password: string,
+    private readonly role = 'citizen'
+  ) {
+    this.client = axios.create({
+      baseURL: new URL('/', idamUrl).toString(),
+    });
+  }
+
+  async create(): Promise<void> {
+    try {
+      await this.client.post('/testing-support/accounts', {
+        email: this.email,
+        forename: 'FunctionalTest',
+        id: 'No Fault Divorce Citizen 12345',
+        password: this.password,
+        roles: [
+          {
+            code: this.role,
+          },
+        ],
+        surname: 'Citizen',
+      });
+      console.info('Created user', this.email);
+    } catch (e) {
+      console.info('Error creating user', this.email, e);
+      throw e;
+    }
+  }
+
+  async delete(): Promise<void> {
+    try {
+      await this.client.delete(`/testing-support/accounts/${this.email}`);
+      console.info('Deleted user', this.email);
+    } catch (e) {
+      console.info('Error deleting user', this.email, e);
+    }
+  }
+}


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

Automatically create IDAM functional test users on test start and delete users on teardown.

Currently the same users are used between individual PR test runs and local runs. If a bunch of PRs or local test runs happen to be running at the same time user states can collide causing inconsistent states and test failures.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
