### PR TITLE
feat(NFDIV-551): Welsh translations for "their email" page

### DIFF
--- a/src/main/steps/their-email-address/content.ts
+++ b/src/main/steps/their-email-address/content.ts
@@ -24,8 +24,23 @@ const en = ({ partner, isDivorce }) => ({
   },
 });
 
-// @TODO translations
-const cy = en;
+const cy = ({ partner }) => ({
+  title: `Nodwch gyfeiriad e-bost eich ${partner}`,
+  line1:
+    "Mae'n bwysig eich bod yn darparu ei gyfeiriad/chyfeiriad e-bost fel y gall y llys 'gyflwyno' (danfon) dogfennau iddo/iddi ar-lein. Os na fyddwch yn darparu cyfeiriad e-bost, bydd y papurau ysgariad yn cael eu cyflwyno (eu danfon) drwy'r post. Bydd y negeseuon e-bost hefyd yn cynnwys gwybodaeth a diweddariadau sy'n ymwneud â'r ysgariad.",
+  line2: 'Os ydych yn defnyddio ei gyfeiriad/chyfeiriad e-bost gwaith, dylech ofyn am ganiatâd yn gyntaf.',
+  respondentEmailAddress: `Cyfeiriad e-bost eich ${partner}`,
+  doNotKnowRespondentEmailAddress: 'Nid wyf yn gwybod beth yw ei gyfeiriad/chyfeiriad e-bost',
+  errors: {
+    respondentEmailAddress: {
+      required:
+        "Nid ydych wedi rhoi ei gyfeiriad/chyfeiriad e-bost neu wedi dweud nad ydych yn gwybod beth ydyw. Mae'n rhaid i chi wneud y naill neu'r llall cyn parhau.",
+      incorrect:
+        'Rydych wedi rhoi cyfeiriad e-bost ac wedi nodi nad ydych yn gwybod beth yw ei gyfeiriad/chyfeiriad e-bost. Dim ond un y gallwch ei wneud cyn parhau.',
+      invalid: 'Rydych wedi rhoi cyfeiriad e-bost annilys. Gwiriwch ef a nodwch ef eto cyn parhau.',
+    },
+  },
+});
 
 export const form: FormContent = {
   fields: {


### PR DESCRIPTION
### JIRA link ###

[NFDIV-551](https://tools.hmcts.net/jira/browse/NFDIV-551) Welsh version - Enter respondent's email address

### Change description ###

Adds Welsh translations for the "their email" page.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
