### PR TITLE
delay the active call for 2 minutes

### DIFF
--- a/src/main/assets/js/session-timeout.ts
+++ b/src/main/assets/js/session-timeout.ts
@@ -2,6 +2,7 @@ import { throttle } from 'lodash';
 
 import { TIMED_OUT_URL } from '../../steps/urls';
 
+const activeStart = 2 * 60 * 1000; // 2 minutes
 const eventThrottleTimer = 5 * 60 * 1000; // 5 minutes
 const sessionTimeoutInterval = 20 * 60 * 1000; // 20 minutes
 let timeout;
@@ -38,5 +39,7 @@ const pingUserActive = throttle(() => {
   });
 }, eventThrottleTimer);
 
-['click', 'touchstart', 'mousemove', 'keypress'].forEach(evt => document.addEventListener(evt, pingUserActive));
+setTimeout(() => {
+  ['click', 'touchstart', 'mousemove', 'keypress'].forEach(evt => document.addEventListener(evt, pingUserActive));
+}, activeStart);
 setSaveTimeout();

--- a/src/main/assets/js/session-timeout.ts
+++ b/src/main/assets/js/session-timeout.ts
@@ -33,11 +33,15 @@ const setSaveTimeout = () => {
   }, sessionTimeoutInterval);
 };
 
-const pingUserActive = throttle(() => {
-  fetch('/active').then(() => {
-    setSaveTimeout();
-  });
-}, eventThrottleTimer);
+const pingUserActive = throttle(
+  () => {
+    fetch('/active').then(() => {
+      setSaveTimeout();
+    });
+  },
+  eventThrottleTimer,
+  { trailing: false }
+);
 
 setTimeout(() => {
   ['click', 'touchstart', 'mousemove', 'keypress'].forEach(evt => document.addEventListener(evt, pingUserActive));


### PR DESCRIPTION
### JIRA link ###



### Change description ###
I dont think its ideal for the active event listneners to happen straight away as its an additional call after the user just reloaded the page hence thought it was best to delay it for 2 minutes before it can be activated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
