### PR TITLE
fix: production node-ts memory usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "start": "NODE_ENV=production ts-node -r tsconfig-paths/register src/main/server.ts",
+    "start": "NODE_ENV=production ts-node --transpile-only -r tsconfig-paths/register src/main/server.ts",
     "start:dev": "NODE_ENV=development yarn start:watch",
     "start:docker": "NODE_ENV=docker yarn start:watch",
     "start:watch": "concurrently --handle-input \"nodemon --config nodemon.express.json\" \"nodemon --config nodemon.assets.json\"",


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

Reduces production `ts-node` memory usage from around ~200 MiB to around ~70 MiB.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
