### PR TITLE
fix: when functional tests leave case in an undoable state

### DIFF
--- a/src/test/functional/features/joint-check-your-answers.feature
+++ b/src/test/functional/features/joint-check-your-answers.feature
@@ -1,7 +1,7 @@
 Feature: Check Your Answers (Joint Application)
 
   Background:
-    Given I login
+    Given I create a new user and login
 
   Scenario: Checking answers as a joint applicant
     Given I've completed enough questions correctly to get to the check your answers page as a joint applicant

--- a/src/test/steps/IdamUserManager.ts
+++ b/src/test/steps/IdamUserManager.ts
@@ -4,45 +4,49 @@ import axios, { AxiosInstance } from 'axios';
 
 export class IdamUserManager {
   client: AxiosInstance;
+  users: Set<string> = new Set();
 
-  constructor(
-    idamUrl: string,
-    private readonly email: string,
-    private readonly password: string,
-    private readonly role = 'citizen'
-  ) {
+  constructor(idamUrl: string) {
     this.client = axios.create({
       baseURL: new URL('/', idamUrl).toString(),
     });
   }
 
-  async create(): Promise<void> {
+  async create(email: string, password: string, role = 'citizen'): Promise<void> {
     try {
       await this.client.post('/testing-support/accounts', {
-        email: this.email,
-        forename: 'FunctionalTest',
         id: 'No Fault Divorce Citizen 12345',
-        password: this.password,
+        email,
+        password,
         roles: [
           {
-            code: this.role,
+            code: role,
           },
         ],
-        surname: 'Citizen',
+        forename: 'FunctionalTest',
+        surname: role,
       });
-      console.info('Created user', this.email);
+      this.users.add(email);
+      console.info('Created user', email);
     } catch (e) {
-      console.info('Error creating user', this.email, e);
+      console.info('Error creating user', email, e);
       throw e;
     }
   }
 
-  async delete(): Promise<void> {
+  async delete(email: string): Promise<void> {
     try {
-      await this.client.delete(`/testing-support/accounts/${this.email}`);
-      console.info('Deleted user', this.email);
+      await this.client.delete(`/testing-support/accounts/${email}`);
+      this.users.delete(email);
+      console.info('Deleted user', email);
     } catch (e) {
-      console.info('Error deleting user', this.email, e);
+      console.info('Error deleting user', email, e);
+    }
+  }
+
+  async deleteAll(): Promise<void> {
+    for (const user of this.users) {
+      await this.delete(user);
     }
   }
 }

--- a/src/test/steps/common.ts
+++ b/src/test/steps/common.ts
@@ -23,7 +23,11 @@ Then('the page URL should be {string}', (url: string) => {
 });
 
 Given('I login', () => {
-  login('user');
+  login('citizen');
+});
+
+Given('I create a new user and login', () => {
+  login('citizenSingleton');
 });
 
 export const iClick = (text: string): void => {


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

Some functional tests can leave a users case in an undoable state, for example when the user successfully pays and submits their application or if they're waiting for a joint application response.

In these cases we need to create and use a seperate user so that functional test that get run afterwards aren't locked in an undoable state.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```