### PR TITLE
fix: functional tests when postcode service is unavailable

### DIFF
--- a/src/test/config.ts
+++ b/src/test/config.ts
@@ -62,6 +62,7 @@ export const config = {
       '../steps/check-your-answers.ts',
       '../steps/jurisdiction.ts',
       '../steps/happy-path.ts',
+      '../steps/postcode.ts',
     ],
   },
   bootstrap: async (): Promise<void> => idamUserManager.create(TestUser, TestPass),

--- a/src/test/cross-browser/features/happy-path.feature
+++ b/src/test/cross-browser/features/happy-path.feature
@@ -1,7 +1,7 @@
 Feature: No fault union dissolution application submission
 
   Background:
-    Given I login
+    Given I create a new user and login
     When I go to '/your-details'
     Then the page should include "Apply for a divorce"
     And I expect the page title to be "Apply for a divorce - Who are you applying to divorce? - GOV.UK"

--- a/src/test/functional/features/application-submitted.feature
+++ b/src/test/functional/features/application-submitted.feature
@@ -1,9 +1,13 @@
-Feature:
+Feature: Submitting an application
 
   Background:
     Given I create a new user and login
+    When I've already completed all questions correctly
+    Then I go to '/check-your-answers'
 
-  Scenario: Completed all required questions and confirming with HWF
-    Given I've completed all happy path questions correctly
-    Given I pay and submit the application
-    And the page should include "Application submitted"
+  Scenario: Completed all required questions and confirming
+    Given I click "I confirm"
+    And I click "I believe that the facts stated in this application are true"
+    When I click "Continue to payment"
+    And I pay and submit the application
+    Then the page should include "Application submitted"

--- a/src/test/functional/features/their-address.feature
+++ b/src/test/functional/features/their-address.feature
@@ -7,20 +7,9 @@ Feature: Their address
     Then the page should include "Enter your husband’s postal address"
 
   Scenario: Entering their partners UK postcode
-    Given I reset the postcode lookup form
-    And I select "Enter a UK postcode"
-    And I type "SW1H 9AJ"
-    When I click "Find address"
-    Then the page should include "SW1H 9AJ"
-    And I wait for the postcode lookup to return results
-    Given I choose "MINISTRY OF JUSTICE, SEVENTH FLOOR, 102, PETTY FRANCE, LONDON, SW1H 9AJ" from "Select an address"
+    Given I enter the UK address "MINISTRY OF JUSTICE, SEVENTH FLOOR, 102, PETTY FRANCE, LONDON, SW1H 9AJ"
     When I click "Continue"
     Then the page URL should be "/other-court-cases"
-    Given I go to "/enter-their-address"
-    Then the form input "Building and street" should be "102 MINISTRY OF JUSTICE, SEVENTH FLOOR, PETTY FRANCE"
-    And the form input "Town or city" should be "LONDON"
-    And the form input "County" should be "CITY OF WESTMINSTER"
-    And the form input "Postcode" should be "SW1H 9AJ"
 
   Scenario: Entering their partners international address
     Given I reset the postcode lookup form

--- a/src/test/functional/features/your-address.feature
+++ b/src/test/functional/features/your-address.feature
@@ -7,20 +7,9 @@ Feature: Your address
     Then the page should include "Enter your postal address"
 
   Scenario: Successfully entering a UK postcode
-    Given I reset the postcode lookup form
-    And I select "Enter a UK postcode"
-    And I type "SW1A 1AA"
-    When I click "Find address"
-    Then the page should include "SW1A 1AA"
-    And I wait for the postcode lookup to return results
-    Given I choose "BUCKINGHAM PALACE, LONDON, SW1A 1AA" from "Select an address"
+    Given I enter the UK address "BUCKINGHAM PALACE, LONDON, SW1A 1AA"
     When I click "Continue"
     Then the page URL should be "/their-email-address"
-    Given I go to "/enter-your-address"
-    Then the form input "Building and street" should be "BUCKINGHAM PALACE"
-    And the form input "Town or city" should be "LONDON"
-    And the form input "County" should be "CITY OF WESTMINSTER"
-    And the form input "Postcode" should be "SW1A 1AA"
 
   Scenario: Successfully entering an international address
     Given I reset the postcode lookup form

--- a/src/test/steps/common.ts
+++ b/src/test/steps/common.ts
@@ -99,21 +99,6 @@ export const iClearTheForm = (): void => {
 };
 Given('I clear the form', iClearTheForm);
 
-export const iWaitForPostcodeLookUpResults = (): void => {
-  I.waitForText('Select an address');
-  I.waitForElement('option[value^="{\\"fullAddress"]', 10);
-};
-Then('I wait for the postcode lookup to return results', iWaitForPostcodeLookUpResults);
-
-export const iResetThePostCodeLookUpForm = (): void => {
-  iClearTheForm();
-
-  I.executeScript(() => {
-    (document.querySelector('[data-link="resetPostcodeLookup"]') as HTMLAnchorElement).click();
-  });
-};
-Given('I reset the postcode lookup form', iResetThePostCodeLookUpForm);
-
 Given("I've said I'm applying as a sole application", () => {
   I.amOnPage('/how-do-you-want-to-apply');
   iClearTheForm();

--- a/src/test/steps/happy-path.ts
+++ b/src/test/steps/happy-path.ts
@@ -1,14 +1,8 @@
 import { APPLY_FINANCIAL_ORDER } from '../../main/steps/urls';
 import { completeCase } from '../functional/fixtures/completeCase';
 
-import {
-  checkOptionFor,
-  iAmOnPage,
-  iClearTheForm,
-  iClick,
-  iSetTheUsersCaseTo,
-  iWaitForPostcodeLookUpResults,
-} from './common';
+import { checkOptionFor, iAmOnPage, iClearTheForm, iClick, iSetTheUsersCaseTo } from './common';
+import { iEnterTheUkAddress } from './postcode';
 
 const { I } = inject();
 
@@ -21,7 +15,7 @@ Given("I've already completed all questions correctly", async () => {
   I.amOnPage(url);
 });
 
-Given("I've completed all happy path questions correctly", () => {
+Given("I've completed all happy path questions correctly", async () => {
   iAmOnPage('/your-details');
   iClearTheForm();
   iClick('My husband');
@@ -110,12 +104,8 @@ Given("I've completed all happy path questions correctly", () => {
   iClick('I do not need my contact details kept private');
   iClick('Continue');
 
-  I.waitInUrl('/enter-your-address');
-  iClick('Enter a UK postcode', '#postcode', 10);
-  I.type('SW1A 1AA');
-  iClick('Find address');
-  iWaitForPostcodeLookUpResults();
-  I.selectOption('Select an address', 'BUCKINGHAM PALACE, LONDON, SW1A 1AA');
+  iAmOnPage('/enter-your-address');
+  await iEnterTheUkAddress('BUCKINGHAM PALACE, LONDON, SW1A 1AA');
   iClick('Continue');
 
   I.waitInUrl('/their-email-address');
@@ -129,11 +119,7 @@ Given("I've completed all happy path questions correctly", () => {
   iClick('Continue');
 
   I.waitInUrl('/enter-their-address');
-  iClick('Enter a UK postcode', '#postcode', 10);
-  I.type('SW1H 9AJ');
-  iClick('Find address');
-  iWaitForPostcodeLookUpResults();
-  I.selectOption('Select an address', 'MINISTRY OF JUSTICE, SEVENTH FLOOR, 102, PETTY FRANCE, LONDON, SW1H 9AJ');
+  await iEnterTheUkAddress('MINISTRY OF JUSTICE, SEVENTH FLOOR, 102, PETTY FRANCE, LONDON, SW1H 9AJ');
   iClick('Continue');
 
   I.waitInUrl('/other-court-cases');

--- a/src/test/steps/postcode.ts
+++ b/src/test/steps/postcode.ts
@@ -1,0 +1,58 @@
+import { iClearTheForm, iClick } from './common';
+
+const { I } = inject();
+
+export const iWaitForPostcodeLookUpResults = async (): Promise<void> => {
+  I.waitForText('Select an address');
+
+  const timeout = 10;
+  const locator = 'option[value^="{\\"fullAddress"]';
+  let numberOfElements = await I.grabNumberOfVisibleElements(locator);
+  let i = 0;
+  while (numberOfElements === 0 && i < timeout) {
+    numberOfElements = await I.grabNumberOfVisibleElements(locator);
+    I.wait(1);
+    i++;
+  }
+
+  if (!numberOfElements) {
+    throw new Error('No postcode search results were returned');
+  }
+};
+Then('I wait for the postcode lookup to return results', iWaitForPostcodeLookUpResults);
+
+export const iResetThePostCodeLookUpForm = (): void => {
+  iClearTheForm();
+
+  I.executeScript(() => {
+    (document.querySelector('[data-link="resetPostcodeLookup"]') as HTMLAnchorElement).click();
+  });
+};
+Given('I reset the postcode lookup form', iResetThePostCodeLookUpForm);
+
+export const iEnterTheUkAddress = async (address: string): Promise<void> => {
+  const addressParts = address.split(', ');
+  const postcode = addressParts[addressParts.length - 1];
+
+  iResetThePostCodeLookUpForm();
+
+  try {
+    iClick('Enter a UK postcode', '#postcode', 10);
+    I.type(postcode);
+    iClick('Find address');
+    await iWaitForPostcodeLookUpResults();
+    I.waitForText(postcode);
+    I.selectOption('Select an address', address);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('Warning: Postcode lookup service failed, entering address manually', e);
+    iClick('I cannot find the address in the list');
+    iClick('Building and street');
+    I.type(addressParts[0]);
+    iClick('Town or city');
+    I.type(addressParts[1]);
+    iClick('Postcode');
+    I.type(postcode);
+  }
+};
+Given('I enter the UK address {string}', iEnterTheUkAddress);


### PR DESCRIPTION
### JIRA link ###

N/A

### Change description ###

When the 3rd party postcode lookup service is unavailable function tests were failing.

This PR checks to see if a result was returned from the postcode search, if not it will enter an address manually.

This also reuses the "completed all questions correctly" for application submission functional test.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
