### PR TITLE
NFDIV-743: Use case reference passed to trigger event

### DIFF
--- a/src/main/app/access-code/AccessCodePostController.test.ts
+++ b/src/main/app/access-code/AccessCodePostController.test.ts
@@ -62,7 +62,7 @@ describe('AccessCodePostController', () => {
 
     expect(getNextStepUrlMock).toBeCalled();
     expect(req.locals.api.triggerEvent).toHaveBeenCalledWith(
-      '1234',
+      '1234123412341234',
       {
         accessCode: 'QWERTY78',
         caseReference: '1234123412341234',

--- a/src/main/app/access-code/AccessCodePostController.ts
+++ b/src/main/app/access-code/AccessCodePostController.ts
@@ -23,9 +23,9 @@ export class AccessCodePostController {
     Object.assign(req.session.userCase, formData);
     this.form.setFormState(req.session.userCase);
     req.session.errors = this.form.getErrors(formData);
+    const caseReference = formData.caseReference?.replace(/-/g, '');
 
     try {
-      const caseReference = formData.caseReference?.replace(/-/g, '');
       const caseData = await req.locals.api.getCaseById(caseReference as string);
 
       if (caseData.accessCode !== formData.accessCode) {
@@ -38,7 +38,7 @@ export class AccessCodePostController {
     if (req.session.errors.length === 0) {
       try {
         req.session.userCase = await req.locals.api.triggerEvent(
-          req.session.userCase.id,
+          caseReference as string,
           formData,
           CITIZEN_LINK_APPLICANT_2
         );

--- a/src/main/app/access-code/AccessCodePostController.ts
+++ b/src/main/app/access-code/AccessCodePostController.ts
@@ -20,8 +20,6 @@ export class AccessCodePostController {
     const { saveAndSignOut, saveBeforeSessionTimeout, _csrf, ...formData } = this.form.getParsedBody(req.body);
 
     formData.respondentUserId = req.session.user.id;
-    Object.assign(req.session.userCase, formData);
-    this.form.setFormState(req.session.userCase);
     req.session.errors = this.form.getErrors(formData);
     const caseReference = formData.caseReference?.replace(/-/g, '');
 

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -5,9 +5,11 @@ import { getRedirectUrl, getUserDetails } from '../../app/auth/user/oidc';
 import { getCaseApi } from '../../app/case/CaseApi';
 import { AppRequest } from '../../app/controller/AppRequest';
 import {
+  APPLICANT_2,
   APPLICANT_2_CALLBACK_URL,
   APPLICANT_2_SIGN_IN_URL,
   CALLBACK_URL,
+  ENTER_YOUR_ACCESS_CODE,
   SIGN_IN_URL,
   SIGN_OUT_URL,
 } from '../../steps/urls';
@@ -48,7 +50,7 @@ export class OidcMiddleware {
             req.query.code,
             APPLICANT_2_CALLBACK_URL
           );
-          req.session.save(() => res.redirect('/enter-your-access-code'));
+          req.session.save(() => res.redirect(ENTER_YOUR_ACCESS_CODE));
         } else {
           res.redirect(APPLICANT_2_SIGN_IN_URL);
         }
@@ -60,12 +62,15 @@ export class OidcMiddleware {
         if (req.session?.user) {
           res.locals.isLoggedIn = true;
           req.locals.api = getCaseApi(req.session.user, req.locals.logger);
-          req.session.userCase =
-            req.session.userCase || (await req.locals.api.getOrCreateCase(res.locals.serviceType, req.session.user));
-          req.session.isApplicant2 = await req.locals.api.isApplicant2(req.session.userCase.id, req.session.user.id);
+
+          if (req.url !== ENTER_YOUR_ACCESS_CODE) {
+            req.session.userCase =
+              req.session.userCase || (await req.locals.api.getOrCreateCase(res.locals.serviceType, req.session.user));
+            req.session.isApplicant2 = await req.locals.api.isApplicant2(req.session.userCase?.id, req.session.user.id);
+          }
 
           return next();
-        } else if (req.url === '/applicant2') {
+        } else if (req.url === APPLICANT_2) {
           res.redirect(APPLICANT_2_SIGN_IN_URL);
         } else {
           res.redirect(SIGN_IN_URL);


### PR DESCRIPTION
When Applicant 2 logs in using the link in the invite email, it creates a new case id for them at the enter-your-access-code page. Currently that is the case id that is triggering the event. This PR will change the logic to use the case reference that is entered as the user which will have been validated with the access code before the event is triggered.