### PR TITLE
Fix partner title for app2

### DIFF
--- a/src/main/app/case/answers/getAnswerRows.ts
+++ b/src/main/app/case/answers/getAnswerRows.ts
@@ -12,12 +12,13 @@ export const getAnswerRows = function (section: Sections): GovUkNunjucksSummary[
   const {
     language,
     isDivorce,
+    isApplicant2,
     formState,
     userEmail,
   }: {
     language: 'en' | 'cy';
     isDivorce: boolean;
-    applicant2: string;
+    isApplicant2: boolean;
     userEmail: string;
     formState: Partial<Case>;
   } = this.ctx;
@@ -37,6 +38,7 @@ export const getAnswerRows = function (section: Sections): GovUkNunjucksSummary[
             language,
             pageContent: step.generateContent,
             isDivorce,
+            isApplicant2,
             formState: processedFormState,
             userEmail,
           }),

--- a/src/main/app/controller/GetController.ts
+++ b/src/main/app/controller/GetController.ts
@@ -25,11 +25,13 @@ export class GetController {
 
     const language = this.getPreferredLanguage(req) as Language;
     const isDivorce = res.locals.serviceType === DivorceOrDissolution.DIVORCE;
+    const isApplicant2 = req.session?.isApplicant2;
     const formState = req.session?.userCase;
     const content = generatePageContent({
       language,
       pageContent: this.content,
       isDivorce,
+      isApplicant2,
       formState,
       userEmail: req.session?.user.email,
     });

--- a/src/main/steps/common/common.content.ts
+++ b/src/main/steps/common/common.content.ts
@@ -1,6 +1,6 @@
 import { capitalize } from 'lodash';
 
-import { CaseWithId } from '../../app/case/case';
+import { CaseWithId, Checkbox } from '../../app/case/case';
 import { ApplicationType, Gender } from '../../app/case/definition';
 import { PageContent, TranslationFn } from '../../app/controller/GetController';
 
@@ -158,18 +158,20 @@ export const generatePageContent = ({
   language,
   pageContent,
   isDivorce = true,
+  isApplicant2 = false,
   formState,
   userEmail,
 }: {
   language: Language;
   pageContent?: TranslationFn;
   isDivorce?: boolean;
+  isApplicant2?: boolean;
   formState?: Partial<CaseWithId>;
   userEmail?: string;
 }): PageContent => {
   const commonTranslations: typeof en = language === 'en' ? en : cy;
   const serviceName = getServiceName(commonTranslations, isDivorce);
-  const selectedGender = formState?.gender as Gender;
+  const selectedGender = getSelectedGender(formState as Partial<CaseWithId>, isApplicant2);
   const partner = getPartnerContent(commonTranslations, selectedGender, isDivorce);
   const contactEmail = isDivorce ? 'contactdivorce@justice.gov.uk' : 'civilpartnership.case@justice.gov.uk';
   const isJointApplication = formState?.applicationType === ApplicationType.JOINT_APPLICATION;
@@ -181,6 +183,7 @@ export const generatePageContent = ({
     partner,
     language,
     isDivorce,
+    isApplicant2,
     formState,
     userEmail,
     contactEmail,
@@ -197,6 +200,13 @@ export const generatePageContent = ({
 const getServiceName = (translations: typeof en, isDivorce: boolean): string => {
   const serviceName = isDivorce ? translations.applyForDivorce : translations.applyForDissolution;
   return capitalize(serviceName);
+};
+
+const getSelectedGender = (formState: Partial<CaseWithId>, isApplicant2: boolean): Gender => {
+  if (isApplicant2 && formState.sameSex === Checkbox.Unchecked) {
+    return formState?.gender === Gender.MALE ? (Gender.FEMALE as Gender) : (Gender.MALE as Gender);
+  }
+  return formState?.gender as Gender;
 };
 
 const getPartnerContent = (translations: typeof en, selectedGender: Gender, isDivorce: boolean): string => {
@@ -217,6 +227,7 @@ export type CommonContent = typeof en & {
   serviceName: string;
   pageContent?: TranslationFn;
   isDivorce: boolean;
+  isApplicant2: boolean;
   formState?: Partial<CaseWithId>;
   partner: string;
   userEmail?: string;

--- a/src/test/unit/utils/defaultViewArgs.ts
+++ b/src/test/unit/utils/defaultViewArgs.ts
@@ -7,6 +7,7 @@ export const defaultViewArgs = {
   getNextIncompleteStepUrl: expect.any(Function),
   isDraft: expect.any(Boolean),
   isDivorce: expect.any(Boolean),
+  isApplicant2: expect.any(Boolean),
   partner: expect.any(String),
   formState: expect.any(Object),
   language: expect.any(String),


### PR DESCRIPTION

### Change description ###
Currently seeing 'your husband' on applicant 2 pages, when it should be 'your wife' and vice versa.
This checks if you're app2, and reverses the selected gender if so


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
