### PR TITLE
Fix jurisdiction on CYA page

### DIFF
--- a/src/main/steps/applicant1/check-your-answers/content.ts
+++ b/src/main/steps/applicant1/check-your-answers/content.ts
@@ -1,13 +1,36 @@
 import { getFormattedDate } from '../../../app/case/answers/formatDate';
 import { getAnswerRows } from '../../../app/case/answers/getAnswerRows';
 import { Checkbox } from '../../../app/case/case';
-import { ApplicationType, ChangedNameHow, YesOrNo } from '../../../app/case/definition';
+import { ApplicationType, ChangedNameHow, JurisdictionConnections, YesOrNo } from '../../../app/case/definition';
 import { TranslationFn } from '../../../app/controller/GetController';
 import { FormContent, FormFieldsFn } from '../../../app/form/Form';
 import { isFieldFilledIn } from '../../../app/form/validation';
 import { Sections } from '../../applicant1Sequence';
 import { CommonContent } from '../../common/common.content';
 import * as urls from '../../urls';
+
+export const connectionBulletPointsText: (connections, partner) => string = (connections, partner) => {
+  const line1 = 'Your answers indicate that you can apply in England and Wales because:';
+  let bulletPointText = '<ul>';
+
+  const connectionBulletPoints = {
+    [JurisdictionConnections.APP_1_APP_2_LAST_RESIDENT]: `you and your ${partner} were both last habitually resident and one of you still lives here`,
+    [JurisdictionConnections.APP_2_RESIDENT]: `your ${partner} is habitually resident`,
+    [JurisdictionConnections.APP_1_RESIDENT_SIX_MONTHS]:
+      'you’re domiciled and habitually resident and have lived here for at least 6 months',
+    [JurisdictionConnections.APP_1_APP_2_DOMICILED]: `both you and your ${partner} are domiciled`,
+    [JurisdictionConnections.RESIDUAL_JURISDICTION]:
+      'the courts of England and Wales have jurisdiction on a residual basis',
+    [JurisdictionConnections.APP_1_DOMICILED]: 'you are domiciled in England or Wales',
+    [JurisdictionConnections.APP_2_DOMICILED]: `your ${partner} is domiciled in England or Wales`,
+  };
+
+  for (const index in connections) {
+    bulletPointText += '<li>' + connectionBulletPoints[connections[index]] + '</li>';
+  }
+
+  return line1 + bulletPointText + '</ul>';
+};
 
 const en = ({ isDivorce, partner, formState, isJointApplication }: CommonContent) => ({
   titleSoFar: 'Check your answers so far',
@@ -51,7 +74,9 @@ const en = ({ isDivorce, partner, formState, isJointApplication }: CommonContent
         .replace(ChangedNameHow.MARRIAGE_CERTIFICATE, 'Marriage certificate')
         .replace(ChangedNameHow.OTHER, 'Another way'),
     },
-    [urls.JURISDICTION_INTERSTITIAL_URL]: { connections: stepContent => stepContent.line1 },
+    [urls.JURISDICTION_INTERSTITIAL_URL]: {
+      connections: formState?.connections?.length === 1 ? stepContent => stepContent.line1 : '',
+    },
     [urls.ENTER_YOUR_ADDRESS]: {
       applicant1Address1: false,
       applicant1Address2: false,
@@ -102,6 +127,14 @@ const en = ({ isDivorce, partner, formState, isJointApplication }: CommonContent
   stepLinks: {
     [urls.JURISDICTION_INTERSTITIAL_URL]: urls.CHECK_JURISDICTION,
     [urls.APPLY_FINANCIAL_ORDER]: urls.MONEY_PROPERTY,
+  },
+  stepAnswersWithHTML: {
+    [urls.JURISDICTION_INTERSTITIAL_URL]: {
+      connections:
+        formState?.connections && formState?.connections?.length > 1
+          ? connectionBulletPointsText(formState?.connections, partner)
+          : '',
+    },
   },
   continueApplication: 'Continue application',
   confirm: `Confirm before ${formState?.applicant1HelpWithFeesRefNo ? 'submitting' : 'continuing'}`,

--- a/src/main/steps/applicant1/connection-summary/content.ts
+++ b/src/main/steps/applicant1/connection-summary/content.ts
@@ -3,54 +3,89 @@ import { TranslationFn } from '../../../app/controller/GetController';
 import { FormContent } from '../../../app/form/Form';
 import { CommonContent } from '../../common/common.content';
 
-const en = ({ isDivorce, partner, formState, habitualResidentHelpText1, habitualResidentHelpText2 }: CommonContent) => {
-  const enHabitualResident = {
-    helpText1: 'Habitual residence',
-    helpText2:
-      'If your lives are mainly based in England or Wales then you’re what is legally known as ‘habitually resident’.',
-    helpText3: habitualResidentHelpText1,
-    helpText4: habitualResidentHelpText2,
-  };
-  const enDomicile = {
-    helpText5: 'Domicile',
-    helpText6:
-      'Your domicile is usually the place in which you were born, regard as your permanent home and to which you have the closest ties.',
-    helpText7:
-      'However, domicile can be more complex, for example, if you or your parents have moved countries in the past.',
-    helpText8: "When you’re born, you acquire a 'domicile of origin'. This is usually:",
-    helpText9:
-      '<ul class="govuk-list govuk-list--bullet"><li class="govuk-list govuk-list--bullet">the country your father was domiciled in if your parents were married </li> <li class="govuk-list govuk-list--bullet">the country your mother was domiciled in if your parents were unmarried, or your father had died before you were born</li></ul>',
-    helpText10:
-      "If you leave your domicile of origin and settle in another country as an adult, the new country may become your 'domicile of choice'.",
-    helpText11: 'If you’re not sure about your domicile, you should get legal advice.',
+export const jurisdictionMoreDetailsContent: (formState) => { connectedToEnglandWales: string; readMore: string } =
+  formState => {
+    const resConnection = enContainsHabitualResConnection(formState.connections);
+    const domConnection = enContainsDomConnection(formState.connections);
+
+    const resTitleReplacement = domConnection ? '<strong>Habitual residence</strong><br><br>' : '';
+    const domTitleReplacement = resConnection ? '<strong>Domicile</strong><br><br>' : '';
+    const bothTexts = resConnection && domConnection ? '<br><br>' : '';
+
+    const resConnectionText = resConnection
+      ? Object.values(resConnection).join('<br><br>').replace('Habitual residence<br><br>', resTitleReplacement)
+      : '';
+    const domConnectionText = domConnection
+      ? Object.values(domConnection)
+          .join('<br><br>')
+          .replace('Domicile<br><br>', domTitleReplacement)
+          .replace('</ul><br><br>', '</ul>')
+          .replace('<br><ul', '<ul')
+      : '';
+
+    const totalText = (resConnection ? resConnectionText : '') + bothTexts + domConnectionText;
+    const readMoreText =
+      resConnection && domConnection
+        ? 'Read more about your connections'
+        : resConnection
+        ? 'Read more about habitual residence'
+        : 'Read more about domicile';
+
+    return { connectedToEnglandWales: totalText, readMore: readMoreText };
   };
 
-  const enContainsHabitualResConnection = (
-    connections: JurisdictionConnections[] | undefined
-  ): typeof enHabitualResident | undefined => {
-    if (
-      connections &&
-      (connections.includes(JurisdictionConnections.APP_1_APP_2_LAST_RESIDENT) ||
-        connections.includes(JurisdictionConnections.APP_2_RESIDENT) ||
-        connections.includes(JurisdictionConnections.APP_1_RESIDENT_SIX_MONTHS))
-    ) {
-      return enHabitualResident;
-    }
-  };
+const enHabitualResident = {
+  helpText1: 'Habitual residence',
+  helpText2:
+    'If your lives are mainly based in England or Wales then you’re what is legally known as ‘habitually resident’.',
+  helpText3:
+    'This may include working, owning property, having children in school, and your main family life taking place in England or Wales.',
+  helpText4:
+    'The examples above aren’t a complete list of what makes up habitual residence, and just because some of them apply to you doesn’t mean you’re habitually resident. If you’re not sure, you should get legal advice.',
+};
+const enDomicile = {
+  helpText5: 'Domicile',
+  helpText6:
+    'Your domicile is usually the place in which you were born, regard as your permanent home and to which you have the closest ties.',
+  helpText7:
+    'However, domicile can be more complex, for example, if you or your parents have moved countries in the past.',
+  helpText8: "When you’re born, you acquire a 'domicile of origin'. This is usually:",
+  helpText9:
+    '<ul class="govuk-list govuk-list--bullet"><li class="govuk-list govuk-list--bullet">the country your father was domiciled in if your parents were married </li> <li class="govuk-list govuk-list--bullet">the country your mother was domiciled in if your parents were unmarried, or your father had died before you were born</li></ul>',
+  helpText10:
+    "If you leave your domicile of origin and settle in another country as an adult, the new country may become your 'domicile of choice'.",
+  helpText11: 'If you’re not sure about your domicile, you should get legal advice.',
+};
 
-  const enContainsDomConnection = (
-    connections: JurisdictionConnections[] | undefined
-  ): typeof enDomicile | undefined => {
-    if (
-      connections &&
-      (connections.includes(JurisdictionConnections.APP_1_APP_2_DOMICILED) ||
-        connections.includes(JurisdictionConnections.APP_1_DOMICILED) ||
-        connections.includes(JurisdictionConnections.APP_2_DOMICILED))
-    ) {
-      return enDomicile;
-    }
-  };
+const enContainsHabitualResConnection = (
+  connections: JurisdictionConnections[] | undefined
+): typeof enHabitualResident | undefined => {
+  if (
+    connections &&
+    (connections.includes(JurisdictionConnections.APP_1_APP_2_LAST_RESIDENT) ||
+      connections.includes(JurisdictionConnections.APP_2_RESIDENT) ||
+      connections.includes(JurisdictionConnections.APP_1_RESIDENT_SIX_MONTHS) ||
+      connections.includes(JurisdictionConnections.APP_1_APP_2_RESIDENT) ||
+      connections.includes(JurisdictionConnections.APP_1_RESIDENT_JOINT) ||
+      connections.includes(JurisdictionConnections.RESIDUAL_JURISDICTION) ||
+      connections.includes(JurisdictionConnections.APP_1_RESIDENT_TWELVE_MONTHS))
+  ) {
+    return enHabitualResident;
+  }
+};
 
+const enContainsDomConnection = (connections: JurisdictionConnections[] | undefined): typeof enDomicile | undefined => {
+  if (
+    connections &&
+    (connections.includes(JurisdictionConnections.APP_1_APP_2_DOMICILED) ||
+      connections.includes(JurisdictionConnections.APP_1_DOMICILED) ||
+      connections.includes(JurisdictionConnections.APP_2_DOMICILED))
+  ) {
+    return enDomicile;
+  }
+};
+
+const en = ({ isDivorce, partner, formState }: CommonContent) => {
   return {
     title: `You can use English or Welsh courts to ${isDivorce ? 'get a divorce' : 'end your civil partnership'}`,
     line1: `Your answers indicate that you can apply ${
@@ -77,7 +112,13 @@ const en = ({ isDivorce, partner, formState, habitualResidentHelpText1, habitual
 const cy: typeof en = en;
 
 export const form: FormContent = {
-  fields: {},
+  fields: {
+    connections: {
+      type: 'hidden',
+      label: l => l.title,
+      labelHidden: true,
+    },
+  },
   submit: {
     text: l => l.continue,
   },

--- a/src/main/steps/applicant1/connection-summary/post.ts
+++ b/src/main/steps/applicant1/connection-summary/post.ts
@@ -1,0 +1,3 @@
+import { JurisdictionPostController } from '../../../app/jurisdiction/JurisdictionPostController';
+
+export default JurisdictionPostController;

--- a/src/main/steps/applicant2/check-your-joint-application/content.ts
+++ b/src/main/steps/applicant2/check-your-joint-application/content.ts
@@ -2,16 +2,20 @@ import { YesOrNo } from '../../../app/case/definition';
 import { TranslationFn } from '../../../app/controller/GetController';
 import { FormContent } from '../../../app/form/Form';
 import { isFieldFilledIn } from '../../../app/form/validation';
-import { generateContent as applicant1GenerateContent } from '../../applicant1/check-your-answers/content';
+import {
+  generateContent as applicant1GenerateContent,
+  connectionBulletPointsText,
+} from '../../applicant1/check-your-answers/content';
+import { jurisdictionMoreDetailsContent } from '../../applicant1/connection-summary/content';
 import { CommonContent } from '../../common/common.content';
 import * as urls from '../../urls';
 
-const moreDetailsComponent = (text: string, title?: string) => {
+export const moreDetailsComponent: (text: string, title?: string) => string = (text: string, title?: string) => {
   return `
   <details class="govuk-details summary" data-module="govuk-details">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
-        Find out more ${title || ''}
+        ${title || 'Find out more '}
       </span>
     </summary>
     <div class="govuk-details__text">
@@ -29,8 +33,6 @@ const labels = ({ isDivorce, partner, required, formState }: CommonContent) => {
         ? 'They have said that they need help paying the fee. They can only use help with the fees if you apply too. That is why you were asked whether you needed help paying the fee.'
         : ''
     }`,
-    connectedToEnglandWales:
-      "If your life is mainly based in England or Wales then you're what is legally known as 'habitually resident'. This may include working, owning property, having children in school, or your main family life taking place in England or Wales.<br>The examples above aren't a complete list of what makes up habitual residence, and just because some of them apply to you doesn't mean you're habitually resident. If you're not sure, you should get legal advice.",
     otherCourtCases:
       'The court only needs to know about court proceedings relating to your marriage, property or children. It does not need to know about other court proceedings.',
   };
@@ -44,15 +46,25 @@ const labels = ({ isDivorce, partner, required, formState }: CommonContent) => {
     continue: 'Continue',
     stepAnswersWithHTML: {
       [urls.HELP_WITH_YOUR_FEE_URL]: {
-        applicant1HelpPayingNeeded: moreDetailsComponent(moreDetailsContent.helpWithFees, 'about help with fees'),
+        applicant1HelpPayingNeeded: moreDetailsComponent(
+          moreDetailsContent.helpWithFees,
+          'Find out more about help with fees'
+        ),
       },
       [urls.JURISDICTION_INTERSTITIAL_URL]: {
-        connections: moreDetailsComponent(moreDetailsContent.connectedToEnglandWales),
+        connections:
+          (formState?.connections && formState?.connections?.length > 1
+            ? connectionBulletPointsText(formState?.connections, partner)
+            : '') +
+          moreDetailsComponent(
+            jurisdictionMoreDetailsContent(formState).connectedToEnglandWales,
+            jurisdictionMoreDetailsContent(formState).readMore
+          ),
       },
       [urls.OTHER_COURT_CASES]: {
         applicant1LegalProceedings: moreDetailsComponent(
           moreDetailsContent.otherCourtCases,
-          'about other court proceedings'
+          'Find out more about other court proceedings'
         ),
       },
     },


### PR DESCRIPTION
### Change description ###

Currently jurisdiction isn't being saved at the connection-summary page which a number of the connections arrive at (as oppose to the you-can-use-english-or-welsh-courts page), so I have added that in as a field + post controller.

I've made the 'Read more about your connections' on the check-your-joint-application page dynamic, based on the different connections, to line up with the content on the confirm-your-joint-application page - https://tools.hmcts.net/jira/browse/NFDIV-722

Also added in the bullet point answers for multiple connections on to the check-your-answers-page as these currently aren't showing up

Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```


<img width="1579" alt="Screenshot 2021-08-03 at 17 20 18" src="https://user-images.githubusercontent.com/52360278/128052290-4c251b58-078b-4c6d-9877-29bf40e36215.png">**
<img width="1524" alt="Screenshot 2021-08-03 at 17 19 32" src="https://user-images.githubusercontent.com/52360278/128052402-2bc5cd26-d2ae-4c8e-abc6-9962b17c5bd5.png">

