### PR TITLE
Fix dividing assets on confirmation page

### DIFF
--- a/src/main/app/case/answers/getAnswerRows.test.ts
+++ b/src/main/app/case/answers/getAnswerRows.test.ts
@@ -3,7 +3,7 @@ import { Sections } from '../../../steps/applicant1Sequence';
 import * as commonContent from '../../../steps/common/common.content';
 import { APPLICANT_2, APPLY_FINANCIAL_ORDER, OTHER_COURT_CASES, YOUR_NAME } from '../../../steps/urls';
 import { Checkbox } from '../case';
-import { YesOrNo } from '../definition';
+import { FinancialOrderFor, YesOrNo } from '../definition';
 
 import { getAnswerRows } from './getAnswerRows';
 
@@ -135,8 +135,8 @@ describe('getAnswerRows()', () => {
       mockFormState = {
         mockField: 'example response',
         applyForFinancialOrder: YesOrNo.YES,
-        whoIsFinancialOrderFor: ['applicant', 'children'],
-        applicant2WhoIsFinancialOrderFor: ['applicant', 'children'],
+        whoIsFinancialOrderFor: [FinancialOrderFor.APPLICANT, FinancialOrderFor.CHILDREN],
+        applicant2WhoIsFinancialOrderFor: [FinancialOrderFor.APPLICANT, FinancialOrderFor.CHILDREN],
         applicant1FullNameOnCertificate: 'Sarah Smith',
         applicant2FullNameOnCertificate: 'Billy Bob',
         applicant1LegalProceedings: YesOrNo.YES,

--- a/src/main/app/case/answers/getAnswerRows.test.ts
+++ b/src/main/app/case/answers/getAnswerRows.test.ts
@@ -3,6 +3,7 @@ import { Sections } from '../../../steps/applicant1Sequence';
 import * as commonContent from '../../../steps/common/common.content';
 import { APPLICANT_2, APPLY_FINANCIAL_ORDER, OTHER_COURT_CASES, YOUR_NAME } from '../../../steps/urls';
 import { Checkbox } from '../case';
+import { YesOrNo } from '../definition';
 
 import { getAnswerRows } from './getAnswerRows';
 
@@ -133,14 +134,14 @@ describe('getAnswerRows()', () => {
 
       mockFormState = {
         mockField: 'example response',
-        applyForFinancialOrder: 'YES',
-        whoIsFinancialOrderFor: ['applicant1', 'children'],
-        applicant2WhoIsFinancialOrderFor: ['applicant2', 'children'],
+        applyForFinancialOrder: YesOrNo.YES,
+        whoIsFinancialOrderFor: ['applicant', 'children'],
+        applicant2WhoIsFinancialOrderFor: ['applicant', 'children'],
         applicant1FullNameOnCertificate: 'Sarah Smith',
         applicant2FullNameOnCertificate: 'Billy Bob',
-        applicant1LegalProceedings: 'YES',
+        applicant1LegalProceedings: YesOrNo.YES,
         applicant1LegalProceedingsRelated: ['marriage', 'property'],
-        applicant2LegalProceedings: 'YES',
+        applicant2LegalProceedings: YesOrNo.YES,
         applicant2LegalProceedingsRelated: ['marriage', 'children'],
       };
       mockCtx = {
@@ -517,7 +518,7 @@ describe('getAnswerRows()', () => {
                 values: [
                   {
                     label: l => l.yes,
-                    value: 'YES',
+                    value: YesOrNo.YES,
                     subFields: {
                       whoIsFinancialOrderFor: {
                         type: 'checkboxes',
@@ -553,7 +554,7 @@ describe('getAnswerRows()', () => {
                 values: [
                   {
                     label: l => l.yes,
-                    value: 'YES',
+                    value: YesOrNo.YES,
                     subFields: {
                       applicant2WhoIsFinancialOrderFor: {
                         type: 'checkboxes',
@@ -721,7 +722,7 @@ describe('getAnswerRows()', () => {
                 values: [
                   {
                     label: l => l.yes,
-                    value: 'YES',
+                    value: YesOrNo.YES,
                     subFields: {
                       applicant1LegalProceedingsRelated: {
                         type: 'checkboxes',
@@ -756,7 +757,7 @@ describe('getAnswerRows()', () => {
                 values: [
                   {
                     label: l => l.yes,
-                    value: 'YES',
+                    value: YesOrNo.YES,
                     subFields: {
                       applicant2LegalProceedingsRelated: {
                         type: 'checkboxes',

--- a/src/main/app/case/answers/getAnswerRows.ts
+++ b/src/main/app/case/answers/getAnswerRows.ts
@@ -4,6 +4,7 @@ import { generatePageContent } from '../../../steps/common/common.content';
 import { APPLICANT_2, APPLY_FINANCIAL_ORDER, OTHER_COURT_CASES, PageLink, YOUR_NAME } from '../../../steps/urls';
 import type { FormOptions } from '../../form/Form';
 import { Case, Checkbox } from '../case';
+import { YesOrNo } from '../definition';
 
 import type { GovUkNunjucksSummary } from './govUkNunjucksSummary';
 import { omitUnreachableAnswers } from './possibleAnswers';
@@ -147,7 +148,12 @@ export const getAnswerRows = function (
           );
         }
 
-        if (section === 'otherCourtCases' && step.url === OTHER_COURT_CASES) {
+        if (
+          section === 'otherCourtCases' &&
+          step.url === OTHER_COURT_CASES &&
+          (processedFormState.applicant1LegalProceedings === YesOrNo.YES ||
+            processedFormState.applicant2LegalProceedings === YesOrNo.YES)
+        ) {
           const totalLegalProceedingsRelated = processedFormState.applicant1LegalProceedingsRelated?.concat(
             processedFormState.applicant2LegalProceedingsRelated || []
           );
@@ -168,7 +174,7 @@ export const getAnswerRows = function (
             'Who is the financial order for? 	',
             processedFormState.whoIsFinancialOrderFor
               ?.join(' / ')
-              .replace('applicant1', 'Me')
+              .replace('applicant', 'Me')
               .replace('children', 'The children')
           );
         }
@@ -182,7 +188,7 @@ export const getAnswerRows = function (
             'Who is the financial order for? 	',
             processedFormState.applicant2WhoIsFinancialOrderFor
               ?.join(' / ')
-              .replace('applicant2', 'Me')
+              .replace('applicant', 'Me')
               .replace('children', 'The children')
           );
         }
@@ -223,7 +229,7 @@ const setUpSteps = (
     return { stepsWithContent, processedFormState };
   } else {
     const stepsWithContent = isCompleteCase
-      ? [...stepsWithContentApplicant2, ...stepsWithContentApplicant1]
+      ? [...stepsWithContentApplicant1, ...stepsWithContentApplicant2]
       : stepsWithContentApplicant2;
 
     const applicant2ProcessedFormState = omitUnreachableAnswers(formState, stepsWithContentApplicant2);

--- a/src/main/app/case/answers/getAnswerRows.ts
+++ b/src/main/app/case/answers/getAnswerRows.ts
@@ -4,7 +4,7 @@ import { generatePageContent } from '../../../steps/common/common.content';
 import { APPLICANT_2, APPLY_FINANCIAL_ORDER, OTHER_COURT_CASES, PageLink, YOUR_NAME } from '../../../steps/urls';
 import type { FormOptions } from '../../form/Form';
 import { Case, Checkbox } from '../case';
-import { YesOrNo } from '../definition';
+import { FinancialOrderFor, YesOrNo } from '../definition';
 
 import type { GovUkNunjucksSummary } from './govUkNunjucksSummary';
 import { omitUnreachableAnswers } from './possibleAnswers';
@@ -174,8 +174,8 @@ export const getAnswerRows = function (
             'Who is the financial order for? 	',
             processedFormState.whoIsFinancialOrderFor
               ?.join(' / ')
-              .replace('applicant', 'Me')
-              .replace('children', 'The children')
+              .replace(FinancialOrderFor.APPLICANT, 'Me')
+              .replace(FinancialOrderFor.CHILDREN, 'The children')
           );
         }
 
@@ -188,8 +188,8 @@ export const getAnswerRows = function (
             'Who is the financial order for? 	',
             processedFormState.applicant2WhoIsFinancialOrderFor
               ?.join(' / ')
-              .replace('applicant', 'Me')
-              .replace('children', 'The children')
+              .replace(FinancialOrderFor.APPLICANT, 'Me')
+              .replace(FinancialOrderFor.CHILDREN, 'The children')
           );
         }
       }

--- a/src/main/steps/applicant1/confirm-your-joint-application/content.ts
+++ b/src/main/steps/applicant1/confirm-your-joint-application/content.ts
@@ -88,7 +88,7 @@ const en = ({ isDivorce, partner, formState }: CommonContent) => ({
     },
     [urls.APPLICANT_2 + urls.APPLY_FINANCIAL_ORDER]: {
       applicant2ApplyForFinancialOrder:
-        formState?.applicant2ApplyForFinancialOrder === YesOrNo.YES ? ' \n\n\n Yes' : ' \n\n No',
+        formState?.applicant2ApplyForFinancialOrder === YesOrNo.YES ? ' \n\n\n Yes' : ' \n\n\n No',
     },
     [urls.HELP_WITH_YOUR_FEE_URL]: {
       applicant1HelpPayingNeeded:

--- a/src/main/steps/applicant1/confirm-your-joint-application/content.ts
+++ b/src/main/steps/applicant1/confirm-your-joint-application/content.ts
@@ -42,6 +42,9 @@ const en = ({ isDivorce, partner, formState }: CommonContent) => ({
     [urls.APPLY_FINANCIAL_ORDER]: {
       applyForFinancialOrder: 'Applicant 1<br><br> Do you want to apply for a financial order?',
     },
+    [urls.APPLICANT_2 + urls.APPLY_FINANCIAL_ORDER]: {
+      applicant2ApplyForFinancialOrder: '<br>Applicant 2<br><br> Do you want to apply for a financial order?',
+    },
     [urls.WHERE_YOUR_LIVES_ARE_BASED_URL]: {
       applicant1LifeBasedInEnglandAndWales: "Is applicant 1's life mainly based in England or Wales?",
       applicant2LifeBasedInEnglandAndWales: "Is applicant 2's life mainly based in England or Wales?",
@@ -51,9 +54,6 @@ const en = ({ isDivorce, partner, formState }: CommonContent) => ({
       applicant2FirstNames: 'First name',
       applicant2MiddleNames: 'Middle name',
       applicant2LastNames: 'Last name',
-    },
-    [urls.APPLICANT_2 + urls.APPLY_FINANCIAL_ORDER]: {
-      applicant2ApplyForFinancialOrder: 'Applicant 2<br><br> Do you want to apply for a financial order?',
     },
   },
   stepAnswers: {
@@ -86,6 +86,10 @@ const en = ({ isDivorce, partner, formState }: CommonContent) => ({
     [urls.APPLY_FINANCIAL_ORDER]: {
       applyForFinancialOrder: formState?.applyForFinancialOrder === YesOrNo.YES ? ' \n\n Yes' : ' \n\n No',
     },
+    [urls.APPLICANT_2 + urls.APPLY_FINANCIAL_ORDER]: {
+      applicant2ApplyForFinancialOrder:
+        formState?.applicant2ApplyForFinancialOrder === YesOrNo.YES ? ' \n\n Yes' : ' \n\n No',
+    },
     [urls.HELP_WITH_YOUR_FEE_URL]: {
       applicant1HelpPayingNeeded:
         formState?.applicant1HelpPayingNeeded === YesOrNo.YES && formState.applicant2HelpPayingNeeded === YesOrNo.YES
@@ -94,14 +98,6 @@ const en = ({ isDivorce, partner, formState }: CommonContent) => ({
             formState?.applicant2HelpPayingNeeded === YesOrNo.YES
           ? 'No'
           : 'No, because both applicants	did not apply',
-    },
-    [urls.HELP_PAYING_HAVE_YOU_APPLIED]: {
-      applicant1AlreadyAppliedForHelpPaying:
-        formState?.applicant1HelpPayingNeeded === YesOrNo.YES &&
-        formState?.applicant1AlreadyAppliedForHelpPaying === YesOrNo.YES
-          ? `Yes
-          ${formState?.applicant1HelpWithFeesRefNo}`
-          : false,
     },
     [urls.JURISDICTION_INTERSTITIAL_URL]: {
       connections: formState?.connections?.length === 1 ? stepContent => stepContent.line1 : '',
@@ -112,18 +108,6 @@ const en = ({ isDivorce, partner, formState }: CommonContent) => ({
         .replace(ChangedNameHow.DEED_POLL, 'Deed poll')
         .replace(ChangedNameHow.MARRIAGE_CERTIFICATE, 'Marriage certificate')
         .replace(ChangedNameHow.OTHER, 'Another way'),
-    },
-    [urls.APPLICANT_2 + urls.APPLY_FINANCIAL_ORDER]: {
-      applicant2ApplyForFinancialOrder:
-        formState?.applicant2ApplyForFinancialOrder === YesOrNo.YES ? ' \n\n Yes' : ' \n\n No',
-    },
-    [urls.APPLICANT_2 + urls.HELP_PAYING_HAVE_YOU_APPLIED]: {
-      applicant2AlreadyAppliedForHelpPaying:
-        formState?.applicant1HelpPayingNeeded === YesOrNo.YES &&
-        formState?.applicant1AlreadyAppliedForHelpPaying === YesOrNo.YES
-          ? `Yes
-            ${formState?.applicant1HelpWithFeesRefNo}`
-          : false,
     },
     [urls.APPLICANT_2 + urls.HOW_DID_YOU_CHANGE_YOUR_NAME]: {
       applicant2NameChangedHow: formState?.applicant2NameChangedHow

--- a/src/main/steps/applicant1/confirm-your-joint-application/content.ts
+++ b/src/main/steps/applicant1/confirm-your-joint-application/content.ts
@@ -88,7 +88,7 @@ const en = ({ isDivorce, partner, formState }: CommonContent) => ({
     },
     [urls.APPLICANT_2 + urls.APPLY_FINANCIAL_ORDER]: {
       applicant2ApplyForFinancialOrder:
-        formState?.applicant2ApplyForFinancialOrder === YesOrNo.YES ? ' \n\n Yes' : ' \n\n No',
+        formState?.applicant2ApplyForFinancialOrder === YesOrNo.YES ? ' \n\n\n Yes' : ' \n\n No',
     },
     [urls.HELP_WITH_YOUR_FEE_URL]: {
       applicant1HelpPayingNeeded:

--- a/src/main/steps/applicant2Sequence.ts
+++ b/src/main/steps/applicant2Sequence.ts
@@ -119,8 +119,8 @@ const sequences: Step[] = [
   },
   {
     url: APPLY_FINANCIAL_ORDER,
-    showInCompleteSection: Sections.DividingAssets,
     showInSection: Sections.DividingAssets,
+    showInCompleteSection: Sections.DividingAssets,
     getNextStep: data =>
       data.applicant2ApplyForFinancialOrder === YesOrNo.YES
         ? APPLY_FINANCIAL_ORDER_DETAILS


### PR DESCRIPTION
### Change description ###
Fix applicant 2 Do you want to apply for a financial order section not showing up on confirmation page


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

<img width="1117" alt="Screenshot 2021-08-26 at 16 15 05" src="https://user-images.githubusercontent.com/52360278/130989399-ae8360fb-bc64-46c8-ac14-4fb9b0bc965b.png">
