### PR TITLE
Fix text duplication in document upload widget

### DIFF
--- a/src/main/assets/js/upload-manager/index.ts
+++ b/src/main/assets/js/upload-manager/index.ts
@@ -20,6 +20,8 @@ const initUploadManager = (): void => {
   const csrfQuery = `?_csrf=${csrfToken}`;
   location.hash = '';
 
+  const chooseFilePhoto = 'Choose a file or take a photo';
+
   const uppy = new Uppy({
     restrictions: {
       maxFileSize: 10485760,
@@ -37,7 +39,7 @@ const initUploadManager = (): void => {
       target: '#upload',
       locale: {
         strings: {
-          chooseFiles: getById('upload')?.textContent || '',
+          chooseFiles: chooseFilePhoto,
         },
       },
     })

--- a/src/main/steps/applicant1/upload-your-documents/template.njk
+++ b/src/main/steps/applicant1/upload-your-documents/template.njk
@@ -99,7 +99,7 @@
       <span class="upload-arrow-icon govuk-!-margin-bottom-5"></span>
       <div class="govuk-form-group">
         <p class="govuk-body govuk-!-margin-bottom-0">
-          <span id="upload">{{ chooseFilePhoto }}</span>
+          <span id="upload"></span>
           <strong>{{ orStr }}</strong><br>
           {{ dragDropHere }}
         </p>

--- a/src/main/steps/applicant2/upload-your-documents/template.njk
+++ b/src/main/steps/applicant2/upload-your-documents/template.njk
@@ -94,7 +94,7 @@
       <span class="upload-arrow-icon govuk-!-margin-bottom-5"></span>
       <div class="govuk-form-group">
         <p class="govuk-body govuk-!-margin-bottom-0">
-          <span id="upload">{{ chooseFilePhoto }}</span>
+          <span id="upload"></span>
           <strong>{{ orStr }}</strong><br>
           {{ dragDropHere }}
         </p>


### PR DESCRIPTION
Before:
![Uploading Screenshot 2021-09-01 at 10.15.52.png…]()


Now with code change:
<img width="1440" alt="Screenshot 2021-09-01 at 11 07 53" src="https://user-images.githubusercontent.com/20407957/131654303-e51f0be5-492a-4362-bae8-b4fc42e490c2.png">
