### PR TITLE
NFDIV-1138: Fix uploaded documents list on CYA page

### DIFF
--- a/src/main/steps/applicant2/check-your-answers/content.ts
+++ b/src/main/steps/applicant2/check-your-answers/content.ts
@@ -14,6 +14,14 @@ const labels = ({ formState }: CommonContent) => ({
         .replace(ChangedNameHow.MARRIAGE_CERTIFICATE, 'Marriage certificate')
         .replace(ChangedNameHow.OTHER, 'Another way'),
     },
+    [urls.APPLICANT_2 + urls.UPLOAD_YOUR_DOCUMENTS]: {
+      applicant2UploadedFiles: (formState?.applicant2DocumentsUploaded || []).length
+        ? `${formState?.applicant2DocumentsUploaded?.reduce(
+            (acc, curr) => `${acc}${curr.value?.documentFileName}\n`,
+            ''
+          )}`
+        : false,
+    },
   },
 });
 


### PR DESCRIPTION
Before:
<img width="1108" alt="Screenshot 2021-09-01 at 09 46 58" src="https://user-images.githubusercontent.com/20407957/131704037-ac0299a1-51a3-4b8b-838d-a74d4cedbe86.png">


After code change:
<img width="1440" alt="Screenshot 2021-09-01 at 16 52 56" src="https://user-images.githubusercontent.com/20407957/131704057-fd573c5f-3fe0-421f-85c0-d5ae66505ca4.png">
