### PR TITLE
show all residences under what it means

### DIFF
--- a/src/main/steps/applicant1/confirm-your-joint-application/content.ts
+++ b/src/main/steps/applicant1/confirm-your-joint-application/content.ts
@@ -53,7 +53,7 @@ const en = ({ isDivorce, partner, userCase, userEmail, isApplicant2 }: CommonCon
     }.
     The applicants confirmed that the legal statement(s) in the application apply to either or both the applicants. Each legal statement includes some or all of the following legal connections to England or Wales.` +
     '<br><br>' +
-    jurisdictionMoreDetailsContent(userCase.connections, isDivorce).connectedToEnglandWales,
+    jurisdictionMoreDetailsContent(userCase.connections, isDivorce, true).connectedToEnglandWales,
   whatThisMeans: 'What this means',
   subHeading4: 'Other court cases',
   line18: `The court needs to know about any other court cases relating to the ${

--- a/src/main/steps/applicant1/connection-summary/content.ts
+++ b/src/main/steps/applicant1/connection-summary/content.ts
@@ -6,14 +6,14 @@ import { CommonContent } from '../../common/common.content';
 export const jurisdictionMoreDetailsContent = (
   connections: JurisdictionConnections[] | undefined,
   isDivorce: boolean,
-  isRespondent = false
+  showAllResidences = false
 ): { connectedToEnglandWales: string; readMore: string } => {
   const habConnection = enContainsHabitualResConnection(connections);
   const domConnection = enContainsDomConnection(connections);
   const residualConnection = enContainsResidualConnection(connections, isDivorce);
 
   const connectionIndex =
-    isRespondent || (habConnection && domConnection && residualConnection)
+    showAllResidences || (habConnection && domConnection && residualConnection)
       ? 3
       : habConnection && domConnection
       ? 4


### PR DESCRIPTION

### JIRA link ###
https://tools.hmcts.net/jira/secure/RapidBoard.jspa?rapidView=1609&projectKey=NFDIV&view=detail&selectedIssue=NFDIV-1286


### Change description ###
Currently the displayed residence under what it means dropdown is dynamic.  Remove that and default to showing alll residences


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
