### PR TITLE
Change use of email from session to explicitly use applicant1Email

### DIFF
--- a/src/main/app/case/case.ts
+++ b/src/main/app/case/case.ts
@@ -66,6 +66,7 @@ export const formFieldsToCaseMapping: Partial<Record<keyof Case, keyof CaseData>
   applicant1ChangedNameHowAnotherWay: 'applicant1NameChangedHowOtherDetails',
   applicant2NameChangedHow: 'applicant2NameChangedHow',
   applicant2ChangedNameHowAnotherWay: 'applicant2NameChangedHowOtherDetails',
+  applicant1Email: 'applicant1Email',
   applicant2Email: 'applicant2Email',
   applicant2EmailAddress: 'applicant2InviteEmailAddress',
   applicant2PhoneNumber: 'applicant2PhoneNumber',
@@ -210,6 +211,7 @@ export interface Case {
   applicant2NameChangedHow?: ChangedNameHow[];
   applicant1ChangedNameHowAnotherWay?: string;
   applicant2ChangedNameHowAnotherWay?: string;
+  applicant1Email?: string;
   applicant2Email?: string;
   applicant2EmailAddress?: string;
   applicant1DoesNotKnowApplicant2EmailAddress?: Checkbox;

--- a/src/main/steps/applicant1/confirm-your-joint-application/content.ts
+++ b/src/main/steps/applicant1/confirm-your-joint-application/content.ts
@@ -14,7 +14,7 @@ const isSubmit = (isApplicant2: boolean, userCase: Partial<CaseWithId>): boolean
   isApplicant2 ||
   (userCase.applicant1HelpPayingNeeded === YesOrNo.YES && userCase.applicant2HelpPayingNeeded === YesOrNo.YES);
 
-const en = ({ isDivorce, partner, userCase, userEmail, isApplicant2 }: CommonContent) => ({
+const en = ({ isDivorce, partner, userCase, isApplicant2 }: CommonContent) => ({
   title: 'Confirm your joint application',
   subHeader: `This is the information you and your ${partner} have provided for your joint application. Confirm it before continuing.`,
   subHeading1: `Joint ${isDivorce ? 'divorce application' : 'application to end a civil partnership'}`,
@@ -127,7 +127,7 @@ const en = ({ isDivorce, partner, userCase, userEmail, isApplicant2 }: CommonCon
       .join('<br>')
   }`,
   subHeading8: "Applicant 1's email address",
-  line19: `${userEmail}`,
+  line19: `${userCase.applicant1Email}`,
   subHeading9: "Applicant 2's postal address",
   respondentAddressCountry: `${
     userCase.applicant2SolicitorAddress ||
@@ -144,7 +144,7 @@ const en = ({ isDivorce, partner, userCase, userEmail, isApplicant2 }: CommonCon
       .join('<br>')
   }`,
   subHeading10: "Applicant 2's email address",
-  line20: `${userCase.applicant2EmailAddress}`,
+  line20: `${userCase.applicant2Email}`,
   confirm: `Confirm before  ${isSubmit(isApplicant2, userCase) ? 'submitting' : 'continuing'}`,
   confirmPrayer: `I confirm that I’m applying to the court to ${
     isDivorce ? 'dissolve my marriage (get a divorce)' : 'end my civil partnership'


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/NFDIV-1778


### Change description ###
Applicant2's email was displaying under Applicant1 Email title, due to the fact we set the email using the session var. Changed to explicitly use applicant1Email from the case-api backend.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
