### PR TITLE
Fix undefined showing for middle name of applicant2 on confirm-your-joint-application page

### DIFF
--- a/src/main/steps/applicant1/confirm-your-joint-application/content.ts
+++ b/src/main/steps/applicant1/confirm-your-joint-application/content.ts
@@ -10,14 +10,11 @@ import { isFieldFilledIn } from '../../../app/form/validation';
 import { enConnectionBulletPointsSummarisedForAllUsers } from '../../../app/jurisdiction/bulletedPointsContent';
 import { jurisdictionMoreDetailsContent } from '../../../app/jurisdiction/moreDetailsContent';
 import { CommonContent } from '../../common/common.content';
+import { getName } from '../hub-page/content';
 
 const isSubmit = (isApplicant2: boolean, userCase: Partial<CaseWithId>): boolean =>
   isApplicant2 ||
   (userCase.applicant1HelpPayingNeeded === YesOrNo.YES && userCase.applicant2HelpPayingNeeded === YesOrNo.YES);
-
-const getName = (userCase: Partial<CaseWithId>, app: 'applicant1' | 'applicant2') => {
-  return [userCase[app + 'FirstNames'], userCase[app + 'MiddleNames'], userCase[app + 'LastNames']].join(' ');
-};
 
 const en = ({ isDivorce, partner, userCase, isApplicant2, isJointApplication }: CommonContent) => ({
   title: 'Confirm your joint application',

--- a/src/main/steps/applicant1/confirm-your-joint-application/content.ts
+++ b/src/main/steps/applicant1/confirm-your-joint-application/content.ts
@@ -15,6 +15,10 @@ const isSubmit = (isApplicant2: boolean, userCase: Partial<CaseWithId>): boolean
   isApplicant2 ||
   (userCase.applicant1HelpPayingNeeded === YesOrNo.YES && userCase.applicant2HelpPayingNeeded === YesOrNo.YES);
 
+const getName = (userCase: Partial<CaseWithId>, app: 'applicant1' | 'applicant2') => {
+  return [userCase[app + 'FirstNames'], userCase[app + 'MiddleNames'], userCase[app + 'LastNames']].join(' ');
+};
+
 const en = ({ isDivorce, partner, userCase, isApplicant2, isJointApplication }: CommonContent) => ({
   title: 'Confirm your joint application',
   subHeader: `This is the information you and your ${partner} have provided for your joint application. Confirm it before continuing.`,
@@ -27,9 +31,9 @@ const en = ({ isDivorce, partner, userCase, isApplicant2, isJointApplication }: 
   }`,
   line3: `<strong>Case number: </strong>${userCase.id?.replace(/(\\d{4})(\\d{4})(\\d{4})(\\d{4})/, '$1-$2-$3-$4')}`,
   line4: '<strong> Applicant 1 </strong>',
-  line5: `${userCase.applicant1FirstNames} ${userCase.applicant1MiddleNames} ${userCase.applicant1LastNames}`,
+  line5: `${getName(userCase, 'applicant1')}`,
   line6: '<strong> Applicant 2 </strong>',
-  line7: `${userCase.applicant2FirstNames} ${userCase.applicant2MiddleNames} ${userCase.applicant2LastNames}`,
+  line7: `${getName(userCase, 'applicant2')}`,
   subHeading2: `About the ${isDivorce ? 'marriage' : 'civil partnership'}`,
   line8: `These details are copied directly from the ${isDivorce ? 'marriage' : 'civil partnership'} certificate,
      or the translation of the certificate, if it’s not in English. The names on the certificate are the names the

--- a/src/main/steps/applicant1/hub-page/content.ts
+++ b/src/main/steps/applicant1/hub-page/content.ts
@@ -13,7 +13,7 @@ import { generateContent as jointGenerateContent } from './joint/content';
 import { generateContent as columnGenerateContent } from './right-column/content';
 import { generateContent as soleGenerateContent } from './sole/content';
 
-const getName = (userCase: Partial<CaseWithId>, app: 'applicant1' | 'applicant2') => {
+export const getName = (userCase: Partial<CaseWithId>, app: 'applicant1' | 'applicant2'): string => {
   return [userCase[app + 'FirstNames'], userCase[app + 'MiddleNames'], userCase[app + 'LastNames']].join(' ');
 };
 


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/NFDIV-1859


### Change description ###
Use method to handle names having undefined string values on confirm your joint application page.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

<img width="1055" alt="image" src="https://user-images.githubusercontent.com/95974886/159017369-9dd3f83f-9606-4ec1-97f6-8374b78add92.png">
