### PR TITLE
Add missing dateFinalOrderNoLongerEligible field for NPE

### DIFF
--- a/src/test/functional/features/final-order.feature
+++ b/src/test/functional/features/final-order.feature
@@ -49,6 +49,7 @@ Feature: Final order
   Scenario: Respondent sole final order journey
     Given I set the case state to "FinalOrderOverdue"
     Given a superuser updates "dateFinalOrderEligibleToRespondent" with "2022-01-01"
+    And a superuser updates "dateFinalOrderNoLongerEligible" with "2022-01-01"
     When I click "Sign out"
     And I login with applicant "2"
 

--- a/src/test/functional/features/final-order.feature
+++ b/src/test/functional/features/final-order.feature
@@ -48,8 +48,8 @@ Feature: Final order
 
   Scenario: Respondent sole final order journey
     Given I set the case state to "FinalOrderOverdue"
-    Given a superuser updates "dateFinalOrderEligibleToRespondent" with "2022-01-01"
-    And a superuser updates "dateFinalOrderNoLongerEligible" with "2022-01-01"
+    Given a superuser updates "dateFinalOrderEligibleToRespondent" with "2021-01-01"
+    And a superuser updates "dateFinalOrderNoLongerEligible" with "2021-10-01"
     When I click "Sign out"
     And I login with applicant "2"
 


### PR DESCRIPTION
### Change description ###

- To fix NPE:
<img width="522" alt="Screenshot 2022-03-22 at 11 51 21" src="https://user-images.githubusercontent.com/70265071/159475725-d7bd44eb-5c45-440a-a5ad-5da5447f16de.png">


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
