### PR TITLE
NFDIV-1954 - Two "for" attributes for the same input element

### DIFF
--- a/src/main/app/form/Form.ts
+++ b/src/main/app/form/Form.ts
@@ -145,6 +145,7 @@ export interface FormOptions {
   label?: Label;
   labelHidden?: boolean;
   labelSize?: string | null;
+  labelAttributes?: Record<string, string>;
   hideError?: boolean;
   values: FormInput[];
   attributes?: Partial<HTMLInputElement | HTMLTextAreaElement>;

--- a/src/main/steps/applicant1/how-the-court-will-contact-you/content.ts
+++ b/src/main/steps/applicant1/how-the-court-will-contact-you/content.ts
@@ -77,6 +77,9 @@ export const form: FormContent = {
     applicant1PhoneNumber: {
       type: 'tel',
       label: l => l.byPhone,
+      labelAttributes: {
+        for: '',
+      },
       hint: l =>
         `<p class="govuk-body">${l.byPhoneLine1}</p>
         <label class="govuk-label govuk-!-font-weight-bold" for="applicant1PhoneNumber">${l.applicantPhoneNumber}</label>`,

--- a/src/main/steps/applicant2/how-the-court-will-contact-you/content.ts
+++ b/src/main/steps/applicant2/how-the-court-will-contact-you/content.ts
@@ -38,6 +38,9 @@ export const form: FormContent = {
     applicant2PhoneNumber: {
       type: 'tel',
       label: l => l.byPhone,
+      labelAttributes: {
+        for: '',
+      },
       hint: l =>
         `<p class="govuk-body">${l.byPhoneLine1}</p>
         <label class="govuk-label govuk-!-font-weight-bold" for="applicant2PhoneNumber">${l.applicantPhoneNumber}</label>`,

--- a/src/main/steps/common/form/fields/input.njk
+++ b/src/main/steps/common/form/fields/input.njk
@@ -7,7 +7,8 @@
   classes: field.classes,
   label: {
     text: getContent(field.label) if not field.labelHidden else "",
-    classes: labelClasses
+    classes: labelClasses,
+    attributes: field.labelAttributes
   },
   hint: {
     html: getContent(field.hint)


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/NFDIV-1954

### Change description ###

Solution for the following problem:
- Voice activation users navigating the ‘How the court will contact you’ page and want to provide a contact number can find that the ‘Enter your phone number (Optional)’ text input does not respond to its visible label. This is because a ‘for’ attribute is used on the ‘By phone’ text and ‘Enter your phone number (Optional)’ that both match the id of the text input. This will make Dragon voice activation software choose the first label instead of the second label.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
