### PR TITLE
Revert "chore(deps-dev): bump @wdio/sauce-service from 7.20.4 to 7.25 (#2263)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@types/jest": "^27.5.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.30.0",
-    "@wdio/sauce-service": "^7.20.5",
+    "@wdio/sauce-service": "^7.20.4",
     "allure-commandline": "^2.17.2",
     "axios-debug-log": "^0.8.4",
     "codeceptjs": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,17 +1483,17 @@
   dependencies:
     "@wdio/utils" "7.20.3"
 
-"@wdio/sauce-service@^7.20.5":
-  version "7.20.5"
-  resolved "https://registry.yarnpkg.com/@wdio/sauce-service/-/sauce-service-7.20.5.tgz#ced2c806a338925a03816cf40538ffc87cd5ac4e"
-  integrity sha512-p7c4L7pX9e/kmudi0+N2Y3rXLAr/FwK3+k0B+bMNSOgNO/t44eOOXFttqsu/UAfCJAxomleKTxP/M0v9+/omMA==
+"@wdio/sauce-service@^7.20.4":
+  version "7.20.4"
+  resolved "https://registry.yarnpkg.com/@wdio/sauce-service/-/sauce-service-7.20.4.tgz#b7d91e522e81c1c69ff5906afd9f9c2e2c04614d"
+  integrity sha512-nIHO36idS8y152a+9krCDv8moeRjwgo1J3uUuBpyxN964zQF/aMoyfFdoAOIKIUY8Khj9npL4il69dhvl9fJjw==
   dependencies:
     "@types/node" "^18.0.0"
     "@wdio/logger" "7.19.0"
     "@wdio/types" "7.20.3"
     "@wdio/utils" "7.20.3"
     saucelabs "^7.1.3"
-    webdriverio "7.20.5"
+    webdriverio "7.20.4"
 
 "@wdio/types@7.20.3":
   version "7.20.3"
@@ -9892,10 +9892,10 @@ webdriver@7.20.4:
     ky "^0.30.0"
     lodash.merge "^4.6.1"
 
-webdriverio@7.20.5, webdriverio@^7.20.4:
-  version "7.20.5"
-  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-7.20.5.tgz#55e0b702bacb0214a7cb20c8155924f4a28c3deb"
-  integrity sha512-GcONsT2eOTXnjwMxvilc95uWTUlzWRBpdbxC1M+664uTfzomCFDMHMsa+evPSKG5+pFMSCrEL67nwRtoLXhh9Q==
+webdriverio@7.20.4, webdriverio@^7.20.4:
+  version "7.20.4"
+  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-7.20.4.tgz#5754a76d1b6a1e45ce82303341ffef3336a45493"
+  integrity sha512-hX6MNRHBaU2KDzQJ0SFWYh/hZi16lorqNrECeMYHsN4kUYNawyOFGktIrhfiuSJOnmreOLHtCGzRu1+kRmMSiw==
   dependencies:
     "@types/aria-query" "^5.0.0"
     "@types/node" "^18.0.0"


### PR DESCRIPTION
### Change description ###

- This reverts commit 7faa5aebc8cf4ffdb20a681fdd4bfd88468e79d0.
- To (potentially) fix failing XB tests

