### PR TITLE
Fix form failure's e2e test

### DIFF
--- a/src/main/steps/applicant1/their-email-address/content.ts
+++ b/src/main/steps/applicant1/their-email-address/content.ts
@@ -67,9 +67,6 @@ export const form: FormContent = {
       label: l => l.applicant2EmailAddress,
       labelSize: null,
       validator: (value, formData) => {
-        if (value === userCase.applicant1Email) {
-          return 'sameEmail';
-        }
         if (formData.applicant1DoesNotKnowApplicant2EmailAddress !== Checkbox.Checked) {
           return isFieldFilledIn(value) || isApplicant2EmailValid(value as string, userCase.applicant1Email);
         } else if (value) {

--- a/src/test/functional/features/form-failures.feature
+++ b/src/test/functional/features/form-failures.feature
@@ -74,7 +74,7 @@ Feature: Form failures
     And I select "Your spouse's email address"
     And I type my own email address
     When I click "Continue"
-    Then the page should include "You have entered your own email address. You need to enter your spouse's email before continuing."
+    Then the page should include "You have entered your own email address. You need to enter your spouse's email address before continuing."
 
     Given I go to "/do-you-have-address"
     When I click "Continue"


### PR DESCRIPTION
Fix form failure's e2e test by updating the error message content expected to see. 
Remove unneccessary line in the their-email-address form validator
