### PR TITLE
Fix routes for enter your access code

### DIFF
--- a/src/main/steps/applicant2/enter-your-access-code/get.test.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.test.ts
@@ -8,9 +8,6 @@ import { generateContent } from './content';
 import { Applicant2AccessCodeGetController } from './get';
 
 jest.mock('../../../app/auth/user/oidc');
-jest.mock('../../../app/case/case-api', () => ({
-  getCaseApi: () => ({ isApplicantAlreadyLinked: jest.fn() }),
-}));
 
 describe('AccessCodeGetController', () => {
   const controller = new Applicant2AccessCodeGetController();


### PR DESCRIPTION
### Change description ###

Fix routes for enter your access code page. Issue currently is that users are linking to a case and then logging back in through the applicant 2 linking URL and seeing the enter-your-access-code page again incorrectly.

