### PR TITLE
Nfdiv-2581 Fix applicant2 log in

### DIFF
--- a/src/main/steps/applicant2/enter-your-access-code/get.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.ts
@@ -1,9 +1,25 @@
+import autobind from 'autobind-decorator';
+import { Response } from 'express';
+
+import { getSystemUser } from '../../../app/auth/user/oidc';
+import { getCaseApi } from '../../../app/case/case-api';
+import { AppRequest } from '../../../app/controller/AppRequest';
 import { GetController } from '../../../app/controller/GetController';
+import { HOME_URL } from '../../urls';
 
 import { generateContent } from './content';
 
 export class Applicant2AccessCodeGetController extends GetController {
   constructor() {
     super(__dirname + '/template.njk', generateContent);
+  }
+
+  @autobind
+  public async get(req: AppRequest, res: Response): Promise<void> {
+    const api = getCaseApi(await getSystemUser(), req.locals.logger);
+    if (await api.isApplicantAlreadyLinked(res.locals.serviceType, req.session.user)) {
+      return res.redirect(HOME_URL);
+    }
+    await super.get(req, res);
   }
 }


### PR DESCRIPTION
### Change description ###

This is an issue caused by [NFDIV-2175](https://tools.hmcts.net/jira/browse/NFDIV-2175) where applicant 2 users are unable to login through the applicant 2 URL without seeing the enter-your-access-code page even though they have already linked on to the case.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2581

