### PR TITLE
nfdiv-2585 Fix old divorce redirect

### DIFF
--- a/src/main/app/case/case-api.test.ts
+++ b/src/main/app/case/case-api.test.ts
@@ -149,7 +149,19 @@ describe('CaseApi', () => {
   });
 
   test('Should throw an error if in progress divorce case is found', async () => {
+    const userCase = [
+      {
+        id: '1234',
+        state: State.Draft,
+        case_data: {
+          divorceOrDissolution: DivorceOrDissolution.DIVORCE,
+          applicationFeeOrderSummary: [{ test: 'fees' }],
+          applicationPayments: [{ test: 'payment' }],
+        },
+      },
+    ];
     const mockCase = [{ case_data: { D8DivorceUnit: 'serviceCentre' }, state: 'AwaitingDecreeNisi' }];
+    mockApiClient.findExistingUserCases.mockReturnValueOnce(userCase);
     mockApiClient.findExistingUserCases.mockResolvedValue(mockCase);
 
     try {

--- a/src/main/app/case/case-api.test.ts
+++ b/src/main/app/case/case-api.test.ts
@@ -2,7 +2,7 @@ import * as oidc from '../auth/user/oidc';
 import { UserDetails } from '../controller/AppRequest';
 import { PaymentModel } from '../payment/PaymentModel';
 
-import { CaseApi, InProgressDivorceCase, getCaseApi } from './case-api';
+import { CaseApi, getCaseApi } from './case-api';
 import * as caseApiClient from './case-api-client';
 import { CITIZEN_ADD_PAYMENT, CITIZEN_UPDATE, DivorceOrDissolution, State, UserRole } from './definition';
 
@@ -146,33 +146,6 @@ describe('CaseApi', () => {
     mockApiClient.findExistingUserCases.mockRejectedValue(new Error('Case could not be retrieved.'));
 
     await expect(api.getExistingUserCase(serviceType)).rejects.toThrow('Case could not be retrieved.');
-  });
-
-  test('Should throw an error if in progress divorce case is found', async () => {
-    const userCase = [
-      {
-        id: '1234',
-        state: State.Draft,
-        case_data: {
-          divorceOrDissolution: DivorceOrDissolution.DIVORCE,
-          applicationFeeOrderSummary: [{ test: 'fees' }],
-          applicationPayments: [{ test: 'payment' }],
-        },
-      },
-    ];
-    const mockCase = [{ case_data: { D8DivorceUnit: 'serviceCentre' }, state: 'AwaitingDecreeNisi' }];
-    mockApiClient.findExistingUserCases.mockReturnValueOnce(userCase);
-    mockApiClient.findExistingUserCases.mockResolvedValue(mockCase);
-
-    try {
-      await api.getExistingUserCase(serviceType);
-    } catch (err) {
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(err instanceof InProgressDivorceCase).toBeTruthy();
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(err.message).toBe('User has in progress divorce case');
-      return;
-    }
   });
 
   test('Should ignore incomplete divorce cases', async () => {

--- a/src/main/app/case/case-api.ts
+++ b/src/main/app/case/case-api.ts
@@ -9,10 +9,6 @@ import { CASE_TYPE, CITIZEN_ADD_PAYMENT, DivorceOrDissolution, ListValue, Paymen
 import { fromApiFormat } from './from-api-format';
 import { toApiFormat } from './to-api-format';
 
-export class InProgressDivorceCase implements Error {
-  constructor(public readonly message: string, public readonly name = 'DivCase') {}
-}
-
 export class CaseApi {
   readonly maxRetries: number = 3;
 

--- a/src/main/app/case/case-api.ts
+++ b/src/main/app/case/case-api.ts
@@ -1,4 +1,3 @@
-import config from 'config';
 import { LoggerInstance } from 'winston';
 
 import { getSystemUser } from '../auth/user/oidc';
@@ -38,9 +37,6 @@ export class CaseApi {
   }
 
   public async getExistingUserCase(serviceType: string): Promise<CaseWithId | false> {
-    if (config.get('services.case.checkDivCases') && (await this.hasInProgressDivorceCase())) {
-      throw new InProgressDivorceCase('User has in progress divorce case');
-    }
     const userCases = await this.apiClient.findExistingUserCases(CASE_TYPE, serviceType);
     return this.getLatestUserCase(userCases);
   }
@@ -58,7 +54,7 @@ export class CaseApi {
     return this.apiClient.sendEvent(caseId, { applicationPayments: payments }, CITIZEN_ADD_PAYMENT);
   }
 
-  private async hasInProgressDivorceCase(): Promise<boolean> {
+  public async hasInProgressDivorceCase(): Promise<boolean> {
     const userCase = (await this.apiClient.findExistingUserCases('DIVORCE', 'DIVORCE'))[0];
     if (userCase) {
       const courtId = (userCase.case_data as unknown as Record<string, string>).D8DivorceUnit;

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -79,16 +79,6 @@ export class OidcMiddleware {
 
       const existingUserCase = await req.locals.api.getExistingUserCase(res.locals.serviceType);
 
-      if (
-        !existingUserCase &&
-        !newInviteUserCase &&
-        config.get('services.case.checkDivCases') &&
-        (await req.locals.api.hasInProgressDivorceCase())
-      ) {
-        const token = encodeURIComponent(req.session.user.accessToken);
-        return res.redirect(config.get('services.decreeNisi.url') + `/authenticated?__auth-token=${token}`);
-      }
-
       let redirectUrl;
       if (newInviteUserCase && existingUserCase) {
         req.session.inviteCaseId = newInviteUserCase.id;
@@ -103,6 +93,12 @@ export class OidcMiddleware {
           redirectUrl = `${APPLICANT_2}${ENTER_YOUR_ACCESS_CODE}`;
         }
       } else {
+        if (!existingUserCase) {
+          if (await req.locals.api.hasInProgressDivorceCase()) {
+            const token = encodeURIComponent(req.session.user.accessToken);
+            return res.redirect(config.get('services.decreeNisi.url') + `/authenticated?__auth-token=${token}`);
+          }
+        }
         req.session.userCase =
           req.session.userCase ||
           existingUserCase ||

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -94,7 +94,7 @@ export class OidcMiddleware {
         }
       } else {
         if (!existingUserCase) {
-          if (await req.locals.api.hasInProgressDivorceCase()) {
+          if (config.get('services.case.checkDivCases') && (await req.locals.api.hasInProgressDivorceCase())) {
             const token = encodeURIComponent(req.session.user.accessToken);
             return res.redirect(config.get('services.decreeNisi.url') + `/authenticated?__auth-token=${token}`);
           }


### PR DESCRIPTION
### Change description ###

Fix old divorce redirect.
Update to only send them to old divorce if they haven’t got an existing NFD case AND they haven’t been invited as a respondent/applicant2 to a NFD case

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2585

