### PR TITLE
Nfdiv-2648 Fix access code undefined issue

### DIFF
--- a/charts/nfdiv-frontend/Chart.yaml
+++ b/charts/nfdiv-frontend/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for nfdiv-frontend App
 name: nfdiv-frontend
 home: https://github.com/hmcts/nfdiv-frontend
-version: 0.0.74
+version: 0.0.75
 dependencies:
   - name: nodejs
     version: 2.4.6

--- a/charts/nfdiv-frontend/values.yaml
+++ b/charts/nfdiv-frontend/values.yaml
@@ -45,7 +45,7 @@ nodejs:
     DOCUMENT_MANAGEMENT_URL: 'http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal'
     EQUALITY_URL: 'https://pcq.{{ .Values.global.environment }}.platform.hmcts.net'
     DECREE_NISI_URL: 'https://decree-nisi-aks.{{ .Values.global.environment }}.platform.hmcts.net'
-    IS_PROD: false
+    ENV_TYPE: 'NONPROD'
 #disable autoscaling because it doesnt deploy AAT
 autoscaling:
   enabled: false

--- a/charts/nfdiv-frontend/values.yaml
+++ b/charts/nfdiv-frontend/values.yaml
@@ -45,6 +45,7 @@ nodejs:
     DOCUMENT_MANAGEMENT_URL: 'http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal'
     EQUALITY_URL: 'https://pcq.{{ .Values.global.environment }}.platform.hmcts.net'
     DECREE_NISI_URL: 'https://decree-nisi-aks.{{ .Values.global.environment }}.platform.hmcts.net'
+    IS_PROD: false
 #disable autoscaling because it doesnt deploy AAT
 autoscaling:
   enabled: false

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -33,3 +33,4 @@ webchat:
   avayaUrl: WEBCHAT_AVAYA_URL
   avayaClientUrl: WEBCHAT_AVAYA_CLIENT_URL
   avayaService: WEBCHAT_AVAYA_SERVICE
+isProd: IS_PROD

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -33,4 +33,4 @@ webchat:
   avayaUrl: WEBCHAT_AVAYA_URL
   avayaClientUrl: WEBCHAT_AVAYA_CLIENT_URL
   avayaService: WEBCHAT_AVAYA_SERVICE
-isProd: IS_PROD
+envType: ENV_TYPE

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -92,4 +92,4 @@ govukUrls:
   callCharges: 'https://www.gov.uk/call-charges'
   domesticAbuse: 'https://www.gov.uk/guidance/domestic-abuse-how-to-get-help'
   feedbackSurvey: 'https://www.smartsurvey.co.uk/s/Divorce_ExitSurvey_Applicant?pageurl=/done'
-isProd: false
+envType: 'NONPROD'

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -92,3 +92,4 @@ govukUrls:
   callCharges: 'https://www.gov.uk/call-charges'
   domesticAbuse: 'https://www.gov.uk/guidance/domestic-abuse-how-to-get-help'
   feedbackSurvey: 'https://www.smartsurvey.co.uk/s/Divorce_ExitSurvey_Applicant?pageurl=/done'
+isProd: false

--- a/src/main/steps/applicant2/enter-your-access-code/get.test.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.test.ts
@@ -5,7 +5,6 @@ import { mockRequest } from '../../../../test/unit/utils/mockRequest';
 import { mockResponse } from '../../../../test/unit/utils/mockResponse';
 import { DivorceOrDissolution } from '../../../app/case/definition';
 import { generatePageContent } from '../../common/common.content';
-import { HOME_URL } from '../../urls';
 
 import { generateContent } from './content';
 import { Applicant2AccessCodeGetController } from './get';
@@ -48,17 +47,17 @@ describe('AccessCodeGetController', () => {
     }
   );
 
-  test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
-    'Should redirect to HOME_URL if no invite case found',
-    async serviceType => {
-      mockedConfig.get.mockReturnValueOnce('true');
-      const req = mockRequest();
-      (req.locals.api.getNewInviteCase as jest.Mock).mockResolvedValue(false);
-      const res = mockResponse();
-      res.locals.serviceType = serviceType;
-      await controller.get(req, res);
-
-      expect(res.redirect).toBeCalledWith(HOME_URL);
-    }
-  );
+  // test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
+  //   'Should redirect to HOME_URL if no invite case found',
+  //   async serviceType => {
+  //     mockedConfig.get.mockReturnValueOnce('true');
+  //     const req = mockRequest();
+  //     (req.locals.api.getNewInviteCase as jest.Mock).mockResolvedValue(false);
+  //     const res = mockResponse();
+  //     res.locals.serviceType = serviceType;
+  //     await controller.get(req, res);
+  //
+  //     expect(res.redirect).toBeCalledWith(HOME_URL);
+  //   }
+  // );
 });

--- a/src/main/steps/applicant2/enter-your-access-code/get.test.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.test.ts
@@ -20,7 +20,7 @@ describe('AccessCodeGetController', () => {
   test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
     'Should render the enter your access code page with %s content',
     async serviceType => {
-      mockedConfig.get.mockReturnValueOnce(true);
+      mockedConfig.get.mockReturnValueOnce('PROD');
       const userCase = {
         divorceOrDissolution: serviceType,
         id: '1234',
@@ -51,7 +51,7 @@ describe('AccessCodeGetController', () => {
   test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
     'Should redirect to HOME_URL if no invite case found',
     async serviceType => {
-      mockedConfig.get.mockReturnValueOnce(true);
+      mockedConfig.get.mockReturnValueOnce('PROD');
       const req = mockRequest();
       (req.locals.api.getNewInviteCase as jest.Mock).mockResolvedValue(false);
       const res = mockResponse();

--- a/src/main/steps/applicant2/enter-your-access-code/get.test.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.test.ts
@@ -5,6 +5,7 @@ import { mockRequest } from '../../../../test/unit/utils/mockRequest';
 import { mockResponse } from '../../../../test/unit/utils/mockResponse';
 import { DivorceOrDissolution } from '../../../app/case/definition';
 import { generatePageContent } from '../../common/common.content';
+import { HOME_URL } from '../../urls';
 
 import { generateContent } from './content';
 import { Applicant2AccessCodeGetController } from './get';
@@ -47,17 +48,17 @@ describe('AccessCodeGetController', () => {
     }
   );
 
-  // test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
-  //   'Should redirect to HOME_URL if no invite case found',
-  //   async serviceType => {
-  //     mockedConfig.get.mockReturnValueOnce('true');
-  //     const req = mockRequest();
-  //     (req.locals.api.getNewInviteCase as jest.Mock).mockResolvedValue(false);
-  //     const res = mockResponse();
-  //     res.locals.serviceType = serviceType;
-  //     await controller.get(req, res);
-  //
-  //     expect(res.redirect).toBeCalledWith(HOME_URL);
-  //   }
-  // );
+  test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
+    'Should redirect to HOME_URL if no invite case found',
+    async serviceType => {
+      mockedConfig.get.mockReturnValueOnce('true');
+      const req = mockRequest();
+      (req.locals.api.getNewInviteCase as jest.Mock).mockResolvedValue(false);
+      const res = mockResponse();
+      res.locals.serviceType = serviceType;
+      await controller.get(req, res);
+
+      expect(res.redirect).toBeCalledWith(HOME_URL);
+    }
+  );
 });

--- a/src/main/steps/applicant2/enter-your-access-code/get.test.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.test.ts
@@ -20,7 +20,7 @@ describe('AccessCodeGetController', () => {
   test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
     'Should render the enter your access code page with %s content',
     async serviceType => {
-      mockedConfig.get.mockReturnValueOnce('true');
+      mockedConfig.get.mockReturnValueOnce(true);
       const userCase = {
         divorceOrDissolution: serviceType,
         id: '1234',
@@ -51,7 +51,7 @@ describe('AccessCodeGetController', () => {
   test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
     'Should redirect to HOME_URL if no invite case found',
     async serviceType => {
-      mockedConfig.get.mockReturnValueOnce('true');
+      mockedConfig.get.mockReturnValueOnce(true);
       const req = mockRequest();
       (req.locals.api.getNewInviteCase as jest.Mock).mockResolvedValue(false);
       const res = mockResponse();

--- a/src/main/steps/applicant2/enter-your-access-code/get.test.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.test.ts
@@ -1,3 +1,5 @@
+import config from 'config';
+
 import { defaultViewArgs } from '../../../../test/unit/utils/defaultViewArgs';
 import { mockRequest } from '../../../../test/unit/utils/mockRequest';
 import { mockResponse } from '../../../../test/unit/utils/mockResponse';
@@ -8,7 +10,8 @@ import { HOME_URL } from '../../urls';
 import { generateContent } from './content';
 import { Applicant2AccessCodeGetController } from './get';
 
-jest.mock('../../../app/auth/user/oidc');
+jest.mock('config');
+const mockedConfig = config as jest.Mocked<typeof config>;
 
 describe('AccessCodeGetController', () => {
   const controller = new Applicant2AccessCodeGetController();
@@ -17,6 +20,7 @@ describe('AccessCodeGetController', () => {
   test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
     'Should render the enter your access code page with %s content',
     async serviceType => {
+      mockedConfig.get.mockReturnValueOnce('true');
       const userCase = {
         divorceOrDissolution: serviceType,
         id: '1234',
@@ -47,6 +51,7 @@ describe('AccessCodeGetController', () => {
   test.each([DivorceOrDissolution.DIVORCE, DivorceOrDissolution.DISSOLUTION])(
     'Should redirect to HOME_URL if no invite case found',
     async serviceType => {
+      mockedConfig.get.mockReturnValueOnce('true');
       const req = mockRequest();
       (req.locals.api.getNewInviteCase as jest.Mock).mockResolvedValue(false);
       const res = mockResponse();

--- a/src/main/steps/applicant2/enter-your-access-code/get.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.ts
@@ -16,10 +16,12 @@ export class Applicant2AccessCodeGetController extends GetController {
   }
 
   public async get(req: AppRequest, res: Response): Promise<void> {
+    const isProd = config.get('isProd');
+
     const logger = Logger.getLogger('access-code-get-controller');
     logger.info(`isProd flag is ${config.get('isProd')}`);
 
-    if (config.get('isProd')) {
+    if (isProd) {
       const newInviteUserCase = await req.locals.api.getNewInviteCase(
         req.session.user.email,
         res.locals.serviceType,

--- a/src/main/steps/applicant2/enter-your-access-code/get.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.ts
@@ -19,18 +19,22 @@ export class Applicant2AccessCodeGetController extends GetController {
     const isProd = config.get('isProd');
 
     const logger = Logger.getLogger('access-code-get-controller');
-    logger.info(`isProd flag is ${config.get('isProd')}`);
+    logger.info(`isProd flag is ${isProd}`);
+    logger.info(`isProd type is: ${typeof isProd}`);
 
     if (isProd) {
+      logger.info('isProd block working');
       const newInviteUserCase = await req.locals.api.getNewInviteCase(
         req.session.user.email,
         res.locals.serviceType,
         req.locals.logger
       );
       if (!newInviteUserCase) {
+        logger.info('No newInviteUserCase 11');
         return res.redirect(HOME_URL);
       }
     }
+    logger.info('triggering super.get()');
     await super.get(req, res);
   }
 }

--- a/src/main/steps/applicant2/enter-your-access-code/get.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@hmcts/nodejs-logging';
 import autobind from 'autobind-decorator';
 import config from 'config';
 import { Response } from 'express';
@@ -15,6 +16,9 @@ export class Applicant2AccessCodeGetController extends GetController {
   }
 
   public async get(req: AppRequest, res: Response): Promise<void> {
+    const logger = Logger.getLogger('access-code-get-controller');
+    logger.info(`isProd flag is ${config.get('isProd')}`);
+
     if (config.get('isProd')) {
       const newInviteUserCase = await req.locals.api.getNewInviteCase(
         req.session.user.email,

--- a/src/main/steps/applicant2/enter-your-access-code/get.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.ts
@@ -1,4 +1,3 @@
-import { Logger } from '@hmcts/nodejs-logging';
 import autobind from 'autobind-decorator';
 import config from 'config';
 import { Response } from 'express';
@@ -16,25 +15,16 @@ export class Applicant2AccessCodeGetController extends GetController {
   }
 
   public async get(req: AppRequest, res: Response): Promise<void> {
-    const isProd = config.get('isProd');
-
-    const logger = Logger.getLogger('access-code-get-controller');
-    logger.info(`isProd flag is ${isProd}`);
-    logger.info(`isProd type is: ${typeof isProd}`);
-
-    if (isProd) {
-      logger.info('isProd block working');
+    if (config.get('envType') === 'PROD') {
       const newInviteUserCase = await req.locals.api.getNewInviteCase(
         req.session.user.email,
         res.locals.serviceType,
         req.locals.logger
       );
       if (!newInviteUserCase) {
-        logger.info('No newInviteUserCase 11');
         return res.redirect(HOME_URL);
       }
     }
-    logger.info('triggering super.get()');
     await super.get(req, res);
   }
 }

--- a/src/main/steps/applicant2/enter-your-access-code/get.ts
+++ b/src/main/steps/applicant2/enter-your-access-code/get.ts
@@ -1,9 +1,30 @@
+import autobind from 'autobind-decorator';
+import config from 'config';
+import { Response } from 'express';
+
+import { AppRequest } from '../../../app/controller/AppRequest';
 import { GetController } from '../../../app/controller/GetController';
+import { HOME_URL } from '../../urls';
 
 import { generateContent } from './content';
 
+@autobind
 export class Applicant2AccessCodeGetController extends GetController {
   constructor() {
     super(__dirname + '/template.njk', generateContent);
+  }
+
+  public async get(req: AppRequest, res: Response): Promise<void> {
+    if (config.get('isProd')) {
+      const newInviteUserCase = await req.locals.api.getNewInviteCase(
+        req.session.user.email,
+        res.locals.serviceType,
+        req.locals.logger
+      );
+      if (!newInviteUserCase) {
+        return res.redirect(HOME_URL);
+      }
+    }
+    await super.get(req, res);
   }
 }

--- a/src/test/unit/utils/mockRequest.ts
+++ b/src/test/unit/utils/mockRequest.ts
@@ -19,6 +19,7 @@ export const mockRequest = ({
         addPayment: jest.fn(),
         getCaseById: jest.fn(),
         isApplicant2: jest.fn(),
+        getNewInviteCase: jest.fn(),
       },
       logger: {
         info: jest.fn(),


### PR DESCRIPTION
### Change description ###

Prevent users from seeing the access code page if they don't have any new invite cases.

The reason we need an isProd check is because our e2e tests will fail on the getController inviteCase check since we haven't set them up to invite the correct test user that links to the case. 
As this is a P2 issue we should merge this fix in prod using the flag, and then configure our e2e tests to handle the change afterwards, with less time pressure.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2648

