### PR TITLE
clean up after NFDIV 2636 was implemented

### DIFF
--- a/src/main/steps/applicant1Sequence.ts
+++ b/src/main/steps/applicant1Sequence.ts
@@ -90,7 +90,6 @@ import {
 
 export interface Step {
   url: string;
-  excludeFromContinueApplication?: boolean;
   getNextStep: (data: Partial<CaseWithId>) => PageLink;
 }
 
@@ -331,9 +330,7 @@ export const applicant1PreSubmissionSequence: Step[] = [
   },
   {
     url: NEED_TO_GET_ADDRESS,
-    excludeFromContinueApplication: true,
-    getNextStep: data =>
-      data.iWantToHavePapersServedAnotherWay === Checkbox.Checked ? HOW_TO_APPLY_TO_SERVE : ENTER_THEIR_ADDRESS,
+    getNextStep: () => HOW_TO_APPLY_TO_SERVE,
   },
   {
     url: ENTER_THEIR_ADDRESS,

--- a/src/main/steps/index.test.ts
+++ b/src/main/steps/index.test.ts
@@ -4,7 +4,6 @@ import { Checkbox } from '../app/case/case';
 import { ApplicationType, Gender, State, YesOrNo } from '../app/case/definition';
 import { AppRequest } from '../app/controller/AppRequest';
 
-import { applicant1PreSubmissionSequence } from './applicant1Sequence';
 import {
   APPLICANT_2,
   CHECK_ANSWERS_URL,
@@ -89,16 +88,6 @@ describe('Steps', () => {
       mockReq.session.userCase.gender = Gender.MALE;
       mockReq.session.userCase.sameSex = Checkbox.Unchecked;
       expect(getNextIncompleteStepUrl(mockReq)).toBe(`${HAS_RELATIONSHIP_BROKEN_URL}?customQueryString`);
-    });
-
-    it('goes back one page if the step is incomplete & excluded from continue application', () => {
-      applicant1PreSubmissionSequence[1].excludeFromContinueApplication = true;
-
-      mockReq.originalUrl = HAS_RELATIONSHIP_BROKEN_URL;
-      mockReq.session.userCase.gender = Gender.MALE;
-      mockReq.session.userCase.sameSex = Checkbox.Unchecked;
-      const actual = getNextIncompleteStepUrl(mockReq);
-      expect(actual).toBe(YOUR_DETAILS_URL);
     });
 
     it('returns the upload-your-documents step if user has not completed the form', () => {

--- a/src/main/steps/index.ts
+++ b/src/main/steps/index.ts
@@ -54,13 +54,7 @@ allSequences.forEach((sequence: Step[], i: number) => {
   }
 });
 
-const getNextIncompleteStep = (
-  data: CaseWithId,
-  step: Step,
-  sequence: Step[],
-  removeExcluded = false,
-  checkedSteps: Step[] = []
-): string => {
+const getNextIncompleteStep = (data: CaseWithId, step: Step, sequence: Step[], checkedSteps: Step[] = []): string => {
   const stepField = stepFields[step.url];
   // if this step has a form
   if (stepField) {
@@ -69,17 +63,13 @@ const getNextIncompleteStep = (
     const stepForm = new Form(fields);
     if (!stepForm.isComplete(data) || stepForm.getErrors(data).length > 0) {
       // go to that step
-      return removeExcluded && checkedSteps.length && step.excludeFromContinueApplication
-        ? checkedSteps[checkedSteps.length - 1].url
-        : step.url;
+      return step.url;
     } else {
       // if there are no errors go to the next page and work out what to do
       const nextStepUrl = step.getNextStep(data);
       const nextStep = sequence.find(s => s.url === nextStepUrl);
 
-      return nextStep
-        ? getNextIncompleteStep(data, nextStep, sequence, removeExcluded, checkedSteps.concat(step))
-        : CHECK_ANSWERS_URL;
+      return nextStep ? getNextIncompleteStep(data, nextStep, sequence, checkedSteps.concat(step)) : CHECK_ANSWERS_URL;
     }
   }
 
@@ -95,7 +85,7 @@ export const getNextIncompleteStepUrl = (req: AppRequest): string => {
     [State.ConditionalOrderDrafted, State.ConditionalOrderPending].includes(req.session.userCase.state)
       ? sequence.findIndex(s => s.url.includes(READ_THE_RESPONSE))
       : 0;
-  const url = getNextIncompleteStep(req.session.userCase, sequence[sequenceIndex], sequence, true);
+  const url = getNextIncompleteStep(req.session.userCase, sequence[sequenceIndex], sequence);
 
   const jurisdictionUrls = [
     WHERE_YOUR_LIVES_ARE_BASED_URL,


### PR DESCRIPTION
### Change description ###

Enter a description.
clean up after NFDIV 2636 was implemented which is adding validation to need-to-get-address page and this makes the getNextStep function for the page obsolete.

https://github.com/hmcts/nfdiv-frontend/pull/2410

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2636

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

