### PR TITLE
Revert "chore(deps-dev): bump playwright from 1.24.1 to 1.24.2 (#2395)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "nodemon": "^2.0.19",
     "npm-run-all": "^4.1.5",
     "pa11y": "^6.2.3",
-    "playwright": "^1.24.2",
+    "playwright": "^1.24.1",
     "prettier": "^2.7.1",
     "sass-loader": "^13.0.2",
     "sonar-scanner": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7599,17 +7599,17 @@ pkg-dir@4.2.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.24.2:
-  version "1.24.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.24.2.tgz#47bc5adf3dcfcc297a5a7a332449c9009987db26"
-  integrity sha512-zfAoDoPY/0sDLsgSgLZwWmSCevIg1ym7CppBwllguVBNiHeixZkc1AdMuYUPZC6AdEYc4CxWEyLMBTw2YcmRrA==
+playwright-core@1.24.1:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.24.1.tgz#032eefaa8f674a4253a6c35a86787f2cbfcd8829"
+  integrity sha512-1RoSDe/oTQS1Ct7Pb8i+vcFKbKYpmVIBXk0IUiD8RvCUMnNl7EJF1OSQ9E8TZ5RYamWkW2Psir9e8Doyz1FnhQ==
 
-playwright@^1.24.2:
-  version "1.24.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.24.2.tgz#51e60f128b386023e5ee83deca23453aaf73ba6d"
-  integrity sha512-iMWDLgaFRT+7dXsNeYwgl8nhLHsUrzFyaRVC+ftr++P1dVs70mPrFKBZrGp1fOKigHV9d1syC03IpPbqLKlPsg==
+playwright@^1.24.1:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.24.1.tgz#2d047dc28468e80952cd4cee3ae2223a3ad94abb"
+  integrity sha512-ALAdckGTTZq6cPD/NlWE+OO5cgNBi9BHKk6FoDztlcVNJ07F1buwydTuf8wBu1Jzi+SGOpEfLR/83+2fS84ksQ==
   dependencies:
-    playwright-core "1.24.2"
+    playwright-core "1.24.1"
 
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This reverts commit 5f959a1a72d0ad104ec71c7b58e40eb8fe2ccd24.

Trying to fix crossbrowser tests