### PR TITLE
Format date on the email-resent page

### DIFF
--- a/src/main/steps/applicant1/email-resent/content.ts
+++ b/src/main/steps/applicant1/email-resent/content.ts
@@ -1,3 +1,4 @@
+import { getFormattedDate } from '../../../app/case/answers/formatDate';
 import { TranslationFn } from '../../../app/controller/GetController';
 import type { CommonContent } from '../../common/common.content';
 import { isApplicant2EmailUpdatePossible } from '../../common/content.utils';
@@ -6,7 +7,9 @@ import { THEIR_EMAIL_ADDRESS, YOU_CANNOT_UPDATE_THEIR_EMAIL } from '../../urls';
 const en = ({ partner, userCase }: CommonContent) => ({
   title: 'The email has been resent',
   newAccessDetails: `Your ${partner} will only be able to access the application using the access details from the new email. The access details from the first email are now invalid.`,
-  reviewApplicationDeadline: `They should review your application and provide some further information by ${userCase.dueDate}.`,
+  reviewApplicationDeadline: `They should review your application and provide some further information by ${getFormattedDate(
+    userCase.dueDate
+  )}.`,
   yourNotification:
     'You will receive a notification when they have reviewed. If they do not review then you will be told what you can do to progress the application.',
   updatePartnersEmailAddress: {
@@ -20,7 +23,9 @@ const en = ({ partner, userCase }: CommonContent) => ({
 const cy: typeof en = ({ partner, userCase }: CommonContent) => ({
   title: 'Mae’r neges e-bost wedi’i hail-anfon',
   newAccessDetails: `Bydd rhaid i’ch ${partner} ddefnyddio’r manylion mynediad sydd wedi’u cynnwys yn y neges e-bost newydd i gael mynediad i’r cais. Mae’r manylion mynediad sydd wedi’u cynnwys yn y neges e-bost gyntaf nawr yn annilys.`,
-  reviewApplicationDeadline: `Dylent adolygu’ch cais a darparu’r wybodaeth y gofynnir amdani erbyn ${userCase.dueDate}.`,
+  reviewApplicationDeadline: `Dylent adolygu’ch cais a darparu’r wybodaeth y gofynnir amdani erbyn ${getFormattedDate(
+    userCase.dueDate
+  )}.`,
   yourNotification:
     'Byddwch yn cael hysbysiad pan fyddant wedi adolygu’r cais. Os na fyddant yn ei adolygu, fe gewch wybod beth allwch chi ei wneud i symud y cais yn ei flaen.',
   updatePartnersEmailAddress: {


### PR DESCRIPTION
### Change description ###

- The due date wasn't being formatted on email-resent page.
Before:
![b](https://user-images.githubusercontent.com/70265071/200504419-26a0f2c8-9ba8-44ec-b5a8-3f8f2b01e44b.png)
After:
![a](https://user-images.githubusercontent.com/70265071/200504443-01600309-6039-49ae-ae8b-32e78ea0445b.png)

