### PR TITLE
Change cron nightly trigger 4am to 6pm

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,7 +2,7 @@
 
 properties([
   // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-  pipelineTriggers([cron('H 04 * * *')]),
+  pipelineTriggers([cron('H 18 * * *')]),
   parameters([
     string(name: 'TEST_URL', defaultValue: 'https://nfdiv.aat.platform.hmcts.net', description: 'The URL you want to run tests against'),
   ])


### PR DESCRIPTION
### Change description ###

- AAT will be shutdown between 8pm - 8am so need to change nightly tests time.
