### PR TITLE
Use afterAlways() not after() in Jenkinsfiles

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -36,7 +36,7 @@ withPipeline(type, product, component) {
   loadVaultSecrets(secrets)
   syncBranchesWithMaster(branchesToSync)
 
-  after('build') {
+  afterAlways('build') {
     yarnBuilder.yarn('build')
   }
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -52,11 +52,11 @@ withNightlyPipeline(type, product, component) {
     yarnBuilder.smokeTest()
   }
 
-  after('crossBrowserTest') {
+  afterAlways('crossBrowserTest') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/crossbrowser/reports/**/*'
   }
 
-  after('fullFunctionalTest') {
+  afterAlways('fullFunctionalTest') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/functional/reports/**/*'
   }
 }


### PR DESCRIPTION
### Change description ###

- We have noticed deprecated configuration in HMCTS_j_to_z/nfdiv-frontend/master: Build #715
after(build) is deprecated, consider using 'afterSuccess', 'afterFailure', 'afterAlways' instead This configuration will stop working by 30/01/2023 ( in 46 days )
