### PR TITLE
NFDIV-3204 - Prevent users visiting certain URLs (V2)

### DIFF
--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -25,6 +25,7 @@ import { ExistingApplicationPostController } from './steps/existing-application/
 import { HomeGetController } from './steps/home/get';
 import { NoResponseYetApplicationGetController } from './steps/no-response-yet/get';
 import { PrivacyPolicyGetController } from './steps/privacy-policy/get';
+import { shouldHideRouteFromUser } from './steps/routeHiding';
 import { SaveSignOutGetController } from './steps/save-sign-out/get';
 import * as switchToSoleAppContent from './steps/switch-to-sole-application/content';
 import { SwitchToSoleApplicationGetController } from './steps/switch-to-sole-application/get';
@@ -155,7 +156,11 @@ export class Routes {
 
   private isRouteForUser(req: AppRequest, res: Response, next: NextFunction): void {
     const isApp2Route = [APPLICANT_2, RESPONDENT].some(prefixUrl => req.path.includes(prefixUrl));
-    if (isApp2Route !== req.session.isApplicant2 || !getUserSequence(req).some(r => req.path.includes(r.url))) {
+    if (
+      isApp2Route !== req.session.isApplicant2 ||
+      !getUserSequence(req).some(r => req.path.includes(r.url)) ||
+      shouldHideRouteFromUser(req)
+    ) {
       return res.redirect('/error');
     }
     next();

--- a/src/main/steps/applicant1Sequence.ts
+++ b/src/main/steps/applicant1Sequence.ts
@@ -101,6 +101,11 @@ export interface Step {
   getNextStep: (data: Partial<CaseWithId>) => PageLink;
 }
 
+export interface RoutePermission {
+  urls: PageLink[];
+  condition: (data: Partial<CaseWithId>) => boolean;
+}
+
 export const applicant1PreSubmissionSequence: Step[] = [
   {
     url: YOUR_DETAILS_URL,

--- a/src/main/steps/index.test.ts
+++ b/src/main/steps/index.test.ts
@@ -4,6 +4,9 @@ import { CaseWithId, Checkbox } from '../app/case/case';
 import { ApplicationType, Gender, State, YesOrNo } from '../app/case/definition';
 import { AppRequest } from '../app/controller/AppRequest';
 
+import { applicant1PostSubmissionSequence, applicant1PreSubmissionSequence } from './applicant1Sequence';
+import { applicant2PostSubmissionSequence, applicant2PreSubmissionSequence } from './applicant2Sequence';
+import { respondentSequence } from './respondentSequence';
 import {
   APPLICANT_2,
   CHECK_ANSWERS_URL,
@@ -23,7 +26,6 @@ import {
   getNextIncompleteStepUrl,
   getNextStepUrl,
   getUserSequence,
-  hasSubmittedAos,
   isApplicationReadyToSubmit,
   isConditionalOrderReadyToSubmit,
 } from './index';
@@ -214,22 +216,7 @@ describe('Steps', () => {
       mockReq = mockRequest();
     });
 
-    it('returns a sequence without AoS steps if AoS already submitted', () => {
-      mockReq.session.userCase = {
-        id: '1234',
-        state: State.Holding,
-        dateAosSubmitted: '2021-05-10',
-        applicationType: ApplicationType.SOLE_APPLICATION,
-      } as CaseWithId;
-      mockReq.session.isApplicant2 = true;
-
-      const result = getUserSequence(mockReq);
-      expect(result).toHaveLength(6);
-      expect(result.map(step => step.url)).toContain('/respondent/hub-page');
-      expect(result.map(step => step.url)).not.toContain('/respondent/how-do-you-want-to-respond');
-    });
-
-    it('returns a sequence including AoS steps if AoS not yet submitted', () => {
+    it('returns respondentSequence if is applicant2 and sole', () => {
       mockReq.session.userCase = {
         id: '1234',
         state: State.Holding,
@@ -238,29 +225,61 @@ describe('Steps', () => {
       mockReq.session.isApplicant2 = true;
 
       const result = getUserSequence(mockReq);
-      expect(result).toHaveLength(15);
-      expect(result.map(step => step.url)).toContain('/respondent/how-do-you-want-to-respond');
-    });
-  });
-
-  describe('hasSubmittedAos', () => {
-    test('Returns true if dateAosSubmitted is defined', () => {
-      const userCase: CaseWithId = {
-        id: '1234',
-        state: State.Holding,
-        dateAosSubmitted: '2021-05-10',
-      } as CaseWithId;
-      const result = hasSubmittedAos(userCase);
-      expect(result).toBe(true);
+      expect(result).toEqual(respondentSequence);
     });
 
-    test('Returns false if dateAosSubmitted is undefined', () => {
-      const userCase: CaseWithId = {
+    it('returns applicant2PreSubmissionSequence if is applicant2, joint and pre-submission state', () => {
+      mockReq.session.userCase = {
         id: '1234',
-        state: State.Holding,
+        state: State.Draft,
+        applicationType: ApplicationType.JOINT_APPLICATION,
       } as CaseWithId;
-      const result = hasSubmittedAos(userCase);
-      expect(result).toBe(false);
+      mockReq.session.isApplicant2 = true;
+
+      const result = getUserSequence(mockReq);
+      expect(result).toEqual(applicant2PreSubmissionSequence);
     });
+
+    it('returns applicant2PreSubmissionSequence if is applicant2, joint and post-submission state', () => {
+      mockReq.session.userCase = {
+        id: '1234',
+        state: State.AwaitingFinalOrder,
+        applicationType: ApplicationType.JOINT_APPLICATION,
+      } as CaseWithId;
+      mockReq.session.isApplicant2 = true;
+
+      const result = getUserSequence(mockReq);
+      expect(result).toEqual(applicant2PostSubmissionSequence);
+    });
+
+    test.each([[ApplicationType.JOINT_APPLICATION, ApplicationType.SOLE_APPLICATION]])(
+      'returns applicant1PreSubmissionSequence if is applicant 1, %s and pre-submission state',
+      async applicationType => {
+        mockReq.session.userCase = {
+          id: '1234',
+          state: State.Draft,
+          applicationType,
+        } as CaseWithId;
+        mockReq.session.isApplicant2 = false;
+
+        const result = getUserSequence(mockReq);
+        expect(result).toEqual(applicant1PreSubmissionSequence);
+      }
+    );
+
+    test.each([[ApplicationType.JOINT_APPLICATION, ApplicationType.SOLE_APPLICATION]])(
+      'returns applicant1PostSubmissionSequence if is applicant 1, %s and pre-submission state',
+      async applicationType => {
+        mockReq.session.userCase = {
+          id: '1234',
+          state: State.AwaitingConditionalOrder,
+          applicationType,
+        } as CaseWithId;
+        mockReq.session.isApplicant2 = false;
+
+        const result = getUserSequence(mockReq);
+        expect(result).toEqual(applicant1PostSubmissionSequence);
+      }
+    );
   });
 });

--- a/src/main/steps/index.ts
+++ b/src/main/steps/index.ts
@@ -11,7 +11,6 @@ import { Step, applicant1PostSubmissionSequence, applicant1PreSubmissionSequence
 import { applicant2PostSubmissionSequence, applicant2PreSubmissionSequence } from './applicant2Sequence';
 import { respondentSequence } from './respondentSequence';
 import { currentStateFn } from './state-sequence';
-import { getAosSteps } from './url-utils';
 import {
   APPLICANT_2,
   APPLICATION_SUBMITTED,
@@ -124,10 +123,6 @@ export const isConditionalOrderReadyToSubmit = (data: Partial<CaseWithId>, isApp
     : Boolean(data.applicant1ConfirmInformationStillCorrect);
 };
 
-export const hasSubmittedAos = (userCase: CaseWithId): boolean => {
-  return Boolean(userCase.dateAosSubmitted);
-};
-
 export const getNextStepUrl = (req: AppRequest, data: Partial<CaseWithId>): string => {
   const { path, queryString } = getPathAndQueryString(req);
   const nextStep = allSequences.reduce((list, sequence) => list.concat(...sequence), []).find(s => s.url === path);
@@ -141,11 +136,7 @@ export const getUserSequence = (req: AppRequest): Step[] => {
   const stateSequence = currentStateFn(req.session.userCase.state);
 
   if (req.session.userCase.applicationType === ApplicationType.SOLE_APPLICATION && req.session.isApplicant2) {
-    if (hasSubmittedAos(req.session.userCase)) {
-      return respondentSequence.filter(step => !getAosSteps().includes(step.url));
-    } else {
-      return respondentSequence;
-    }
+    return respondentSequence;
   } else if (req.session.isApplicant2) {
     return stateSequence.isBefore(State.Applicant2Approved)
       ? applicant2PreSubmissionSequence

--- a/src/main/steps/routeHiding.test.ts
+++ b/src/main/steps/routeHiding.test.ts
@@ -1,0 +1,135 @@
+import { mockRequest } from '../../test/unit/utils/mockRequest';
+import { CaseWithId } from '../app/case/case';
+import { ApplicationType, State, YesOrNo } from '../app/case/definition';
+import { AppRequest } from '../app/controller/AppRequest';
+
+import { routeHideConditions, shouldHideRouteFromUser } from './routeHiding';
+import {
+  ACCESSIBILITY_STATEMENT_URL,
+  FINALISING_YOUR_APPLICATION,
+  PageLink,
+  RESPONDENT,
+  REVIEW_THE_APPLICATION,
+} from './urls';
+
+describe('routeHiding', () => {
+  let mockReq: AppRequest;
+  beforeEach(() => {
+    mockReq = mockRequest();
+    mockReq.session.userCase = {
+      id: '1234',
+      applicationType: ApplicationType.JOINT_APPLICATION,
+    } as CaseWithId;
+  });
+
+  describe('shouldHideRouteFromUser()', () => {
+    test('return false if no userCase in session', () => {
+      mockReq.session.userCase = false as unknown as CaseWithId;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeFalsy();
+    });
+
+    test('return false if URL is not in the list of conditions', () => {
+      mockReq.url = ACCESSIBILITY_STATEMENT_URL;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeFalsy();
+    });
+
+    test('return true if URL fulfils the hide condition', () => {
+      mockReq.url = FINALISING_YOUR_APPLICATION;
+      mockReq.session.userCase = {
+        id: '1234',
+        state: State.FinalOrderRequested,
+        applicationType: ApplicationType.JOINT_APPLICATION,
+      } as CaseWithId;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe('routeHideConditions', () => {
+    test('URLs should only be associated with one condition each', () => {
+      const allUrls: PageLink[] = routeHideConditions.map(i => i.urls).flat();
+      expect(new Set(allUrls).size).toEqual(allUrls.length);
+    });
+
+    test('check FINALISING_YOUR_APPLICATION condition (state)', () => {
+      mockReq.url = FINALISING_YOUR_APPLICATION;
+      mockReq.session.userCase.state = State.FinalOrderRequested;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeTruthy();
+    });
+
+    test('check FINALISING_YOUR_APPLICATION condition (applicant1AppliedForFinalOrderFirst)', () => {
+      mockReq.url = FINALISING_YOUR_APPLICATION;
+      mockReq.session.userCase.applicant1AppliedForFinalOrderFirst = YesOrNo.YES;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeTruthy();
+    });
+
+    test('Dont hide FINALISING_YOUR_APPLICATION when s2s-fo not submitted yet (app1)', () => {
+      mockReq.url = FINALISING_YOUR_APPLICATION;
+      mockReq.session.userCase.applicant1AppliedForFinalOrderFirst = YesOrNo.YES;
+      mockReq.session.userCase.doesApplicant1IntendToSwitchToSole = YesOrNo.YES;
+      mockReq.session.userCase.dateApplicant1DeclaredIntentionToSwitchToSoleFo = '2022-10-10';
+
+      mockReq.session.userCase.state = State.AwaitingJointFinalOrder;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeFalsy();
+    });
+
+    test('Hide FINALISING_YOUR_APPLICATION when s2s-fo has been submitted (app1)', () => {
+      mockReq.url = FINALISING_YOUR_APPLICATION;
+      mockReq.session.userCase.applicant1AppliedForFinalOrderFirst = YesOrNo.YES;
+      mockReq.session.userCase.doesApplicant1IntendToSwitchToSole = YesOrNo.YES;
+      mockReq.session.userCase.dateApplicant1DeclaredIntentionToSwitchToSoleFo = '2022-10-10';
+
+      mockReq.session.userCase.state = State.FinalOrderRequested;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeTruthy();
+    });
+
+    test('check RESPONDENT/FINALISING_YOUR_APPLICATION condition (state)', () => {
+      mockReq.url = `${RESPONDENT}${FINALISING_YOUR_APPLICATION}`;
+      mockReq.session.userCase.state = State.FinalOrderRequested;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeTruthy();
+    });
+
+    test('check RESPONDENT/FINALISING_YOUR_APPLICATION condition (applicant2AppliedForFinalOrderFirst)', () => {
+      mockReq.url = `${RESPONDENT}${FINALISING_YOUR_APPLICATION}`;
+      mockReq.session.userCase.applicant2AppliedForFinalOrderFirst = YesOrNo.YES;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeTruthy();
+    });
+
+    test('Dont hide RESPONDENT/FINALISING_YOUR_APPLICATION when s2s-fo not submitted yet (app2)', () => {
+      mockReq.url = `${RESPONDENT}${FINALISING_YOUR_APPLICATION}`;
+      mockReq.session.userCase.applicant2AppliedForFinalOrderFirst = YesOrNo.YES;
+      mockReq.session.userCase.doesApplicant2IntendToSwitchToSole = YesOrNo.YES;
+      mockReq.session.userCase.dateApplicant2DeclaredIntentionToSwitchToSoleFo = '2022-10-10';
+
+      mockReq.session.userCase.state = State.AwaitingJointFinalOrder;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeFalsy();
+    });
+
+    test('Hide RESPONDENT/FINALISING_YOUR_APPLICATION when s2s-fo has been submitted (app2)', () => {
+      mockReq.url = `${RESPONDENT}${FINALISING_YOUR_APPLICATION}`;
+      mockReq.session.userCase.applicant2AppliedForFinalOrderFirst = YesOrNo.YES;
+      mockReq.session.userCase.doesApplicant2IntendToSwitchToSole = YesOrNo.YES;
+      mockReq.session.userCase.dateApplicant2DeclaredIntentionToSwitchToSoleFo = '2022-10-10';
+
+      mockReq.session.userCase.state = State.FinalOrderRequested;
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeTruthy();
+    });
+
+    test('check AoS URL condition', () => {
+      mockReq.url = `${RESPONDENT}${REVIEW_THE_APPLICATION}`;
+      mockReq.session.userCase.dateAosSubmitted = '2021-05-10';
+      const result = shouldHideRouteFromUser(mockReq);
+      expect(result).toBeTruthy();
+    });
+  });
+});

--- a/src/main/steps/routeHiding.ts
+++ b/src/main/steps/routeHiding.ts
@@ -1,0 +1,66 @@
+import { State, YesOrNo } from '../app/case/definition';
+import { AppRequest } from '../app/controller/AppRequest';
+
+import { RoutePermission } from './applicant1Sequence';
+import { getSwitchToSoleFoStatus } from './common/switch-to-sole-content.utils';
+import { convertUrlsToApplicant2Urls, convertUrlsToRespondentUrls } from './url-utils';
+import {
+  CHECK_ANSWERS_URL,
+  DETAILS_OTHER_PROCEEDINGS,
+  DISPUTING_THE_APPLICATION,
+  ENGLISH_OR_WELSH,
+  FINALISING_YOUR_APPLICATION,
+  HOW_DO_YOU_WANT_TO_RESPOND,
+  HOW_THE_COURTS_WILL_CONTACT_YOU,
+  LEGAL_JURISDICTION_OF_THE_COURTS,
+  OTHER_COURT_CASES,
+  PageLink,
+  REVIEW_THE_APPLICATION,
+} from './urls';
+
+export const shouldHideRouteFromUser = (req: AppRequest): boolean => {
+  if (!req.session.userCase) {
+    return false;
+  }
+
+  const routePermission = routeHideConditions.find(i => i.urls.includes(req.url as PageLink));
+  if (routePermission) {
+    return routePermission.condition(req.session.userCase);
+  }
+
+  return false;
+};
+
+export const routeHideConditions: RoutePermission[] = [
+  {
+    urls: [FINALISING_YOUR_APPLICATION],
+    condition: data =>
+      data.state === State.FinalOrderRequested ||
+      (data.applicant1AppliedForFinalOrderFirst === YesOrNo.YES &&
+        !getSwitchToSoleFoStatus(data, false).isIntendingAndAbleToSwitchToSoleFo),
+  },
+  {
+    urls: [
+      ...convertUrlsToApplicant2Urls([FINALISING_YOUR_APPLICATION]),
+      ...convertUrlsToRespondentUrls([FINALISING_YOUR_APPLICATION]),
+    ],
+    condition: data =>
+      data.state === State.FinalOrderRequested ||
+      (data.applicant2AppliedForFinalOrderFirst === YesOrNo.YES &&
+        !getSwitchToSoleFoStatus(data, true).isIntendingAndAbleToSwitchToSoleFo),
+  },
+  {
+    urls: convertUrlsToRespondentUrls([
+      REVIEW_THE_APPLICATION,
+      HOW_DO_YOU_WANT_TO_RESPOND,
+      DISPUTING_THE_APPLICATION,
+      LEGAL_JURISDICTION_OF_THE_COURTS,
+      OTHER_COURT_CASES,
+      DETAILS_OTHER_PROCEEDINGS,
+      HOW_THE_COURTS_WILL_CONTACT_YOU,
+      ENGLISH_OR_WELSH,
+      CHECK_ANSWERS_URL,
+    ]),
+    condition: data => Boolean(data.dateAosSubmitted),
+  },
+];

--- a/src/main/steps/url-utils.test.ts
+++ b/src/main/steps/url-utils.test.ts
@@ -1,4 +1,4 @@
-import { getAosSteps, isLinkingUrl, signInNotRequired } from './url-utils';
+import { isLinkingUrl, signInNotRequired } from './url-utils';
 import { ACCESSIBILITY_STATEMENT_URL, HOME_URL, RESPONDENT } from './urls';
 
 describe('url-utils', () => {
@@ -23,16 +23,6 @@ describe('url-utils', () => {
     test('Returns false if request path is not a "linking" path', () => {
       const result = isLinkingUrl(HOME_URL);
       expect(result).toBe(false);
-    });
-  });
-
-  describe('getAosSteps', () => {
-    test('Returns mapped AoS steps', () => {
-      const result = getAosSteps();
-      for (const step of result) {
-        expect(step.includes(RESPONDENT)).toBeTruthy();
-      }
-      expect(result).toHaveLength(9);
     });
   });
 });

--- a/src/main/steps/url-utils.ts
+++ b/src/main/steps/url-utils.ts
@@ -1,21 +1,12 @@
 import {
   ACCESSIBILITY_STATEMENT_URL,
   APPLICANT_2,
-  CHECK_ANSWERS_URL,
   CONTACT_US,
   COOKIES_URL,
-  DETAILS_OTHER_PROCEEDINGS,
-  DISPUTING_THE_APPLICATION,
-  ENGLISH_OR_WELSH,
   ENTER_YOUR_ACCESS_CODE,
-  HOW_DO_YOU_WANT_TO_RESPOND,
-  HOW_THE_COURTS_WILL_CONTACT_YOU,
-  LEGAL_JURISDICTION_OF_THE_COURTS,
-  OTHER_COURT_CASES,
   PRIVACY_POLICY_URL,
   PageLink,
   RESPONDENT,
-  REVIEW_THE_APPLICATION,
   TERMS_AND_CONDITIONS_URL,
   WEBCHAT_URL,
 } from './urls';
@@ -33,17 +24,8 @@ export const signInNotRequired = (reqPath: string): boolean =>
 export const isLinkingUrl = (reqPath: string): boolean =>
   reqPath.endsWith(APPLICANT_2) || reqPath.endsWith(RESPONDENT) || reqPath.endsWith(ENTER_YOUR_ACCESS_CODE);
 
-export const getAosSteps = (): string[] => {
-  const baseUrls = [
-    REVIEW_THE_APPLICATION,
-    HOW_DO_YOU_WANT_TO_RESPOND,
-    DISPUTING_THE_APPLICATION,
-    LEGAL_JURISDICTION_OF_THE_COURTS,
-    OTHER_COURT_CASES,
-    DETAILS_OTHER_PROCEEDINGS,
-    HOW_THE_COURTS_WILL_CONTACT_YOU,
-    ENGLISH_OR_WELSH,
-    CHECK_ANSWERS_URL,
-  ];
-  return baseUrls.map(url => `${RESPONDENT}${url}`);
-};
+export const convertUrlsToRespondentUrls = (urls: PageLink[]): PageLink[] =>
+  urls.map(url => `${RESPONDENT}${url}` as PageLink);
+
+export const convertUrlsToApplicant2Urls = (urls: PageLink[]): PageLink[] =>
+  urls.map(url => `${APPLICANT_2}${url}` as PageLink);


### PR DESCRIPTION
### Change description ###

- Adding logic where conditions can be chosen for preventing users accessing URLs e.g. we don't want users visiting finalising-the-application URL after they've submitted final order.
- Correction from last PR means that s2s-fo is considered.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3204

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

