### PR TITLE
Add new gov uk payments url to allowed form actions on CSP

### DIFF
--- a/src/main/modules/helmet/index.ts
+++ b/src/main/modules/helmet/index.ts
@@ -58,7 +58,7 @@ export class Helmet {
       "'sha256-gpnWB3ld/ux/M3KURJluvKNOUQ82MPOtzVeCtqK7gmE='",
       "'sha256-ZjdUCAt//TDpVjTXX+6bDfZNwte/RfSYJDgtfQtaoXs='",
     ];
-    const formAction = [self, 'https://www.payments.service.gov.uk'];
+    const formAction = [self, 'https://www.payments.service.gov.uk https://card.payments.service.gov.uk'];
     // Equality URL added to work around redirects after form action - https://github.com/w3c/webappsec-csp/issues/8
     const equalityUrl: string = config.get('services.equalityAndDiversity.url');
     if (equalityUrl) {


### PR DESCRIPTION
### Change description ###

Our service is failing on the frontend due to a change in the uk gov payments service URL which means our CSP doesn't recognise it and is stopping us from redirecting. Adding the URL to try and fix the issue.

