### PR TITLE
Move docker yarn version to 3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,15 @@
 !config/**
 !webpack.config.js
 !version
+!.yarnrc.yml
+
+!node_modules
+
+# Yarn v3
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 # ---- Base image ----
 FROM hmctspublic.azurecr.io/base/node:16-alpine as base
 COPY --chown=hmcts:hmcts . .
-RUN yarn install --production \
-  && yarn cache clean
+
+USER root
+RUN corepack enable
+
+WORKDIR /opt/app
+
+USER hmcts
 
 # ---- Build image ----
 FROM base as build
-RUN yarn --version && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true yarn install && yarn build:prod
+RUN yarn --version && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true yarn install && yarn build:prod && yarn cache clean
 
 # ---- Runtime image ----
 FROM base as runtime


### PR DESCRIPTION
### Change description ###

Dan on Engineering catchup mentioned that teams who upgraded to Yarn3 also needed to move their docker builds are the docker image was relying on Yarn1. He helped me on a call to do this.

This PR is the output.