### PR TITLE
NFDIV-3451: Add check to display the page once

### DIFF
--- a/src/main/app/case/case.ts
+++ b/src/main/app/case/case.ts
@@ -153,6 +153,8 @@ export const formFieldsToCaseMapping: Partial<Record<keyof Case, keyof CaseData>
   doesApplicant2IntendToSwitchToSole: 'doesApplicant2IntendToSwitchToSole',
   dateApplicant2DeclaredIntentionToSwitchToSoleFo: 'dateApplicant2DeclaredIntentionToSwitchToSoleFo',
   finalOrderSwitchedToSole: 'finalOrderSwitchedToSole',
+  applicant1CanIntendToSwitchToSoleFo: 'applicant1CanIntendToSwitchToSoleFo',
+  applicant2CanIntendToSwitchToSoleFo: 'applicant2CanIntendToSwitchToSoleFo',
 };
 
 export function formatCase<OutputFormat>(fields: FieldFormats, data: Partial<Case> | CaseData): OutputFormat {
@@ -362,6 +364,8 @@ export interface Case {
   doesApplicant2IntendToSwitchToSole: YesOrNo;
   dateApplicant2DeclaredIntentionToSwitchToSoleFo: DateAsString;
   finalOrderSwitchedToSole: YesOrNo;
+  applicant1CanIntendToSwitchToSoleFo: YesOrNo;
+  applicant2CanIntendToSwitchToSoleFo: YesOrNo;
 }
 
 export interface CaseWithId extends Case {

--- a/src/main/steps/applicant1/hub-page/joint/content.ts
+++ b/src/main/steps/applicant1/hub-page/joint/content.ts
@@ -7,7 +7,7 @@ import { State, YesOrNo } from '../../../../app/case/definition';
 import { TranslationFn } from '../../../../app/controller/GetController';
 import { SupportedLanguages } from '../../../../modules/i18n';
 import type { CommonContent } from '../../../common/common.content';
-import { hasApplicantAppliedForFoFirst, hasApplicantIntendedToSwitchToSoleFo } from '../../../common/content.utils';
+import { canIntendToSwitchToSoleFo, hasApplicantAppliedForFoFirst } from '../../../common/content.utils';
 import { getSwitchToSoleFoStatus } from '../../../common/switch-to-sole-content.utils';
 import { currentStateFn } from '../../../state-sequence';
 import { APPLICANT_2, FINALISING_YOUR_APPLICATION, HOW_TO_FINALISE_APPLICATION } from '../../../urls';
@@ -328,7 +328,7 @@ export const generateContent: TranslationFn = content => {
     dayjs().isAfter(
       dayjs(userCase.dateFinalOrderSubmitted).add(config.get('dates.finalOrderSubmittedOffsetDays'), 'day')
     ) &&
-    !hasApplicantIntendedToSwitchToSoleFo(userCase, isApplicant2) &&
+    canIntendToSwitchToSoleFo(userCase, isApplicant2) &&
     userCase.state === State.AwaitingJointFinalOrder;
 
   const isFinalOrderAwaitingOrOverdue =

--- a/src/main/steps/applicant1/hub-page/joint/content.ts
+++ b/src/main/steps/applicant1/hub-page/joint/content.ts
@@ -325,9 +325,6 @@ export const generateContent: TranslationFn = content => {
   const finalOrderEligibleAndSecondInTimeFinalOrderNotSubmittedWithin14Days =
     hasApplicantAppliedForFoFirst(userCase, isApplicant2) &&
     dayjs().isBefore(userCase.dateFinalOrderNoLongerEligible) &&
-    dayjs().isAfter(
-      dayjs(userCase.dateFinalOrderSubmitted).add(config.get('dates.finalOrderSubmittedOffsetDays'), 'day')
-    ) &&
     canIntendToSwitchToSoleFo(userCase, isApplicant2) &&
     userCase.state === State.AwaitingJointFinalOrder;
 

--- a/src/main/steps/applicant1/hub-page/joint/content.ts
+++ b/src/main/steps/applicant1/hub-page/joint/content.ts
@@ -7,7 +7,7 @@ import { State, YesOrNo } from '../../../../app/case/definition';
 import { TranslationFn } from '../../../../app/controller/GetController';
 import { SupportedLanguages } from '../../../../modules/i18n';
 import type { CommonContent } from '../../../common/common.content';
-import { hasApplicantAppliedForFoFirst } from '../../../common/content.utils';
+import { hasApplicantAppliedForFoFirst, hasApplicantIntendedToSwitchToSoleFo } from '../../../common/content.utils';
 import { getSwitchToSoleFoStatus } from '../../../common/switch-to-sole-content.utils';
 import { currentStateFn } from '../../../state-sequence';
 import { APPLICANT_2, FINALISING_YOUR_APPLICATION, HOW_TO_FINALISE_APPLICATION } from '../../../urls';
@@ -328,6 +328,7 @@ export const generateContent: TranslationFn = content => {
     dayjs().isAfter(
       dayjs(userCase.dateFinalOrderSubmitted).add(config.get('dates.finalOrderSubmittedOffsetDays'), 'day')
     ) &&
+    !hasApplicantIntendedToSwitchToSoleFo(userCase, isApplicant2) &&
     userCase.state === State.AwaitingJointFinalOrder;
 
   const isFinalOrderAwaitingOrOverdue =

--- a/src/main/steps/common/content.utils.test.ts
+++ b/src/main/steps/common/content.utils.test.ts
@@ -14,6 +14,7 @@ import {
 
 import { CommonContent, en } from './common.content';
 import {
+  canIntendToSwitchToSoleFo,
   formattedCaseId,
   getAppSolAddressFields,
   getApplicant1PartnerContent,
@@ -23,7 +24,6 @@ import {
   getSelectedGender,
   getServiceName,
   hasApplicantAppliedForFoFirst,
-  hasApplicantIntendedToSwitchToSoleFo,
   isApplicant2EmailUpdatePossible,
   latestLegalAdvisorDecisionContent,
   nameChangedHowPossibleValue,
@@ -225,34 +225,34 @@ describe('content.utils', () => {
     });
   });
 
-  describe('hasApplicantIntendedToSwitchToSole', () => {
-    test('Applicant 1 has inteded to switchto sole', () => {
+  describe('canIntendToSwitchToSole', () => {
+    test('Applicant 1 can intend to switch to sole', () => {
       const userCase = {
-        doesApplicant1IntendToSwitchToSole: YesOrNo.YES,
-        doesApplicant2IntendToSwitchToSole: YesOrNo.NO,
+        applicant1CanIntendToSwitchToSoleFo: YesOrNo.YES,
+        applicant2CanIntendToSwitchToSoleFo: YesOrNo.NO,
       } as Partial<CaseWithId>;
       let isApplicant2 = false;
       let expected = true;
-      let actual = hasApplicantIntendedToSwitchToSoleFo(userCase, isApplicant2);
+      let actual = canIntendToSwitchToSoleFo(userCase, isApplicant2);
       expect(actual).toEqual(expected);
       isApplicant2 = true;
       expected = false;
-      actual = hasApplicantIntendedToSwitchToSoleFo(userCase, isApplicant2);
+      actual = canIntendToSwitchToSoleFo(userCase, isApplicant2);
       expect(actual).toEqual(expected);
     });
 
-    test('Applicant 2 has inteded to switchto sole', () => {
+    test('Applicant 2 can intend to switch to sole', () => {
       const userCase = {
-        doesApplicant1IntendToSwitchToSole: YesOrNo.NO,
-        doesApplicant2IntendToSwitchToSole: YesOrNo.YES,
+        applicant1CanIntendToSwitchToSoleFo: YesOrNo.NO,
+        applicant2CanIntendToSwitchToSoleFo: YesOrNo.YES,
       } as Partial<CaseWithId>;
       let isApplicant2 = true;
       let expected = true;
-      let actual = hasApplicantIntendedToSwitchToSoleFo(userCase, isApplicant2);
+      let actual = canIntendToSwitchToSoleFo(userCase, isApplicant2);
       expect(actual).toEqual(expected);
       isApplicant2 = false;
       expected = false;
-      actual = hasApplicantIntendedToSwitchToSoleFo(userCase, isApplicant2);
+      actual = canIntendToSwitchToSoleFo(userCase, isApplicant2);
       expect(actual).toEqual(expected);
     });
   });

--- a/src/main/steps/common/content.utils.test.ts
+++ b/src/main/steps/common/content.utils.test.ts
@@ -23,6 +23,7 @@ import {
   getSelectedGender,
   getServiceName,
   hasApplicantAppliedForFoFirst,
+  hasApplicantIntendedToSwitchToSoleFo,
   isApplicant2EmailUpdatePossible,
   latestLegalAdvisorDecisionContent,
   nameChangedHowPossibleValue,
@@ -221,6 +222,38 @@ describe('content.utils', () => {
       };
       const actual = latestLegalAdvisorDecisionContent(userCase, true);
       expect(actual).toEqual(expect.objectContaining(expected));
+    });
+  });
+
+  describe('hasApplicantIntendedToSwitchToSole', () => {
+    test('Applicant 1 has inteded to switchto sole', () => {
+      const userCase = {
+        doesApplicant1IntendToSwitchToSole: YesOrNo.YES,
+        doesApplicant2IntendToSwitchToSole: YesOrNo.NO,
+      } as Partial<CaseWithId>;
+      let isApplicant2 = false;
+      let expected = true;
+      let actual = hasApplicantIntendedToSwitchToSoleFo(userCase, isApplicant2);
+      expect(actual).toEqual(expected);
+      isApplicant2 = true;
+      expected = false;
+      actual = hasApplicantIntendedToSwitchToSoleFo(userCase, isApplicant2);
+      expect(actual).toEqual(expected);
+    });
+
+    test('Applicant 2 has inteded to switchto sole', () => {
+      const userCase = {
+        doesApplicant1IntendToSwitchToSole: YesOrNo.NO,
+        doesApplicant2IntendToSwitchToSole: YesOrNo.YES,
+      } as Partial<CaseWithId>;
+      let isApplicant2 = true;
+      let expected = true;
+      let actual = hasApplicantIntendedToSwitchToSoleFo(userCase, isApplicant2);
+      expect(actual).toEqual(expected);
+      isApplicant2 = false;
+      expected = false;
+      actual = hasApplicantIntendedToSwitchToSoleFo(userCase, isApplicant2);
+      expect(actual).toEqual(expected);
     });
   });
 

--- a/src/main/steps/common/content.utils.ts
+++ b/src/main/steps/common/content.utils.ts
@@ -132,10 +132,10 @@ export const hasApplicantAppliedForFoFirst = (userCase: Partial<CaseWithId>, isA
     : userCase.applicant1AppliedForFinalOrderFirst === YesOrNo.YES;
 };
 
-export const hasApplicantIntendedToSwitchToSoleFo = (userCase: Partial<CaseWithId>, isApplicant2: boolean): boolean => {
+export const canIntendToSwitchToSoleFo = (userCase: Partial<CaseWithId>, isApplicant2: boolean): boolean => {
   return isApplicant2
-    ? userCase.doesApplicant2IntendToSwitchToSole === YesOrNo.YES
-    : userCase.doesApplicant1IntendToSwitchToSole === YesOrNo.YES;
+    ? userCase.applicant2CanIntendToSwitchToSoleFo === YesOrNo.YES
+    : userCase.applicant1CanIntendToSwitchToSoleFo === YesOrNo.YES;
 };
 
 export const getNameChangeOtherDetailsValidator = (

--- a/src/main/steps/common/content.utils.ts
+++ b/src/main/steps/common/content.utils.ts
@@ -132,6 +132,12 @@ export const hasApplicantAppliedForFoFirst = (userCase: Partial<CaseWithId>, isA
     : userCase.applicant1AppliedForFinalOrderFirst === YesOrNo.YES;
 };
 
+export const hasApplicantIntendedToSwitchToSoleFo = (userCase: Partial<CaseWithId>, isApplicant2: boolean): boolean => {
+  return isApplicant2
+    ? userCase.doesApplicant2IntendToSwitchToSole === YesOrNo.YES
+    : userCase.doesApplicant1IntendToSwitchToSole === YesOrNo.YES;
+};
+
 export const getNameChangeOtherDetailsValidator = (
   fieldName:
     | 'applicant1LastNameChangedWhenMarriedOtherDetails'


### PR DESCRIPTION
Currently intedning to switch to sole page is displayed twice. Adding this check will make sure the page is displayed only once when applicants intend to switch to sole.

### Change description ###

Enter a description.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3451

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

