### PR TITLE
Checkboxes are unset on explain the delay when page is loaded.

### DIFF
--- a/src/main/steps/applicant1/explain-the-delay/content.ts
+++ b/src/main/steps/applicant1/explain-the-delay/content.ts
@@ -43,6 +43,7 @@ export const form: FormContent = {
           name: 'applicant1FinalOrderStatementOfTruth',
           label: l => l.finalOrderStatementOfTruth,
           value: Checkbox.Checked,
+          selected: false,
           validator: isFieldFilledIn,
         },
       ],

--- a/src/main/steps/applicant2/explain-the-delay/content.ts
+++ b/src/main/steps/applicant2/explain-the-delay/content.ts
@@ -31,6 +31,7 @@ export const form: FormContent = {
           name: 'applicant2FinalOrderStatementOfTruth',
           label: l => l.finalOrderStatementOfTruth,
           value: Checkbox.Checked,
+          selected: false,
           validator: isFieldFilledIn,
         },
       ],


### PR DESCRIPTION
### Change description ###

Nightly test fail because the the fo sot of field is set to true before the case goes overdue. This makes sure the checkbox is empty when the page is loaded.

option 2: https://github.com/hmcts/nfdiv-case-api/pull/3388

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

