### PR TITLE
Fix frontend login redirect

### DIFF
--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -41,7 +41,10 @@ export class OidcMiddleware {
       errorHandler(async (req: AppRequest, res: Response, next: NextFunction) => {
         if (req.session?.user) {
           if (req.session.user.roles.includes('caseworker')) {
-            res.redirect('https://manage-case.platform.hmcts.net/');
+            const redirectUrl = app.locals.developmentMode
+              ? 'https://manage-case.aat.platform.hmcts.net/'
+              : 'https://manage-case.platform.hmcts.net/';
+            res.redirect(redirectUrl);
           }
           res.locals.isLoggedIn = true;
           req.locals.api = getCaseApi(req.session.user, req.locals.logger);


### PR DESCRIPTION
### Change description ###

frontend was incorrectly redirecting to production when logging in with a test user caseworker.

We were seeing occationally an error in production
`error: [server] Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client`

it turns out this was the reason for this error. Adding a check for development mode to redirect to aat if true.