### PR TITLE
NFDIV-3856 - Dockerfile change to yarn v3 and production bug fix (radio button conditionals)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,7 @@
 !config/**
 !webpack.config.js
 !version
+!.yarnrc.yml
+!.tsconfig.eslint.json
+!.yarn
+!.yarn/releases/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 # ---- Base image ----
 FROM hmctspublic.azurecr.io/base/node:20-alpine as base
+USER root
+RUN corepack enable
 COPY --chown=hmcts:hmcts . .
-RUN yarn install --ignore-optional --production \
-  && yarn cache clean
-
+USER hmcts
 # ---- Build image ----
 FROM base as build
-RUN yarn --version && yarn install --ignore-optional && yarn build:prod
+RUN yarn --version && yarn install
+RUN yarn build:prod
 
 # ---- Runtime image ----
-FROM base as runtime
+FROM build as runtime
 RUN rm -rf webpack/ webpack.config.js
 COPY --from=build $WORKDIR/src/main ./src/main
 RUN yarn build:ts

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "node-cache": "5.1.2",
     "nunjucks": "3.2.4",
     "otplib": "12.0.1",
-    "pdfjs-dist": "4.0.379",
+    "pdfjs-dist": "^4.0.379",
     "redis": "4.6.12",
     "require-directory": "2.1.1",
     "serve-favicon": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "node-cache": "5.1.2",
     "nunjucks": "3.2.4",
     "otplib": "12.0.1",
-    "pdfjs-dist": "^4.0.379",
+    "pdfjs-dist": "3.11.174",
     "redis": "4.6.12",
     "require-directory": "2.1.1",
     "serve-favicon": "2.5.0",

--- a/src/main/assets/js/pdfjs.ts
+++ b/src/main/assets/js/pdfjs.ts
@@ -1,6 +1,7 @@
-import * as pdfjsLib from 'pdfjs-dist/webpack.mjs';
+import * as pdfjsLib from 'pdfjs-dist';
+import 'pdfjs-dist/build/pdf.worker.js';
 
-pdfjsLib.GlobalWorkerOptions.workerSrc = '/assets/pdf/pdf.worker.mjs';
+pdfjsLib.GlobalWorkerOptions.workerSrc = '/assets/pdf/pdf.worker.js';
 
 const loadingMsg = document.getElementById('loading-msg') as HTMLDivElement;
 const pdfContainer = document.getElementById('pdf-container') as HTMLDivElement;

--- a/src/main/assets/js/pdfjs.ts
+++ b/src/main/assets/js/pdfjs.ts
@@ -1,5 +1,4 @@
-import * as pdfjsLib from 'pdfjs-dist';
-import 'pdfjs-dist/build/pdf.worker.mjs';
+import * as pdfjsLib from 'pdfjs-dist/webpack.mjs';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = '/assets/pdf/pdf.worker.mjs';
 

--- a/webpack/app.js
+++ b/webpack/app.js
@@ -6,7 +6,7 @@ const root = path.resolve(__dirname, './../../');
 const sass = path.resolve(root, './main/assets/scss');
 const images = path.resolve(__dirname, '../src/main/assets/images');
 const locales = path.resolve(__dirname, '../src/main/assets/locales');
-const pdfWorker = path.resolve(__dirname, '../node_modules/pdfjs-dist/build/pdf.worker.mjs');
+const pdfWorker = path.resolve(__dirname, '../node_modules/pdfjs-dist/build/pdf.worker.js');
 
 const copyImages = new CopyWebpackPlugin({
   patterns: [{ from: images, to: 'img' }],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11054,7 +11054,7 @@ __metadata:
     nunjucks: 3.2.4
     otplib: 12.0.1
     pa11y: 7.0.0
-    pdfjs-dist: ^4.0.379
+    pdfjs-dist: 3.11.174
     prettier: 3.1.1
     redis: 4.6.12
     require-directory: 2.1.1
@@ -12039,9 +12039,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pdfjs-dist@npm:^4.0.379":
-  version: 4.0.379
-  resolution: "pdfjs-dist@npm:4.0.379"
+"pdfjs-dist@npm:3.11.174":
+  version: 3.11.174
+  resolution: "pdfjs-dist@npm:3.11.174"
   dependencies:
     canvas: ^2.11.2
     path2d-polyfill: ^2.0.1
@@ -12050,7 +12050,7 @@ __metadata:
       optional: true
     path2d-polyfill:
       optional: true
-  checksum: dc40e9251c4fa178bb54e655ecf370393c913cc276b1444f7314bb856004727c9bde69b7de4bccb4884da3ed0ea2613029d130bcc4c7e4ddc1c842187927734c
+  checksum: 62f5a64ca0b2dbc855701ebf9a65c3e48c3c9aa5d64c50eb42bb9ff50a326f3eddab7f2a134ef0398398b1ccff9d842935b9f31358c9103bdc71406632d1a7fa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11054,7 +11054,7 @@ __metadata:
     nunjucks: 3.2.4
     otplib: 12.0.1
     pa11y: 7.0.0
-    pdfjs-dist: 4.0.379
+    pdfjs-dist: ^4.0.379
     prettier: 3.1.1
     redis: 4.6.12
     require-directory: 2.1.1
@@ -12039,7 +12039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pdfjs-dist@npm:4.0.379":
+"pdfjs-dist@npm:^4.0.379":
   version: 4.0.379
   resolution: "pdfjs-dist@npm:4.0.379"
   dependencies:


### PR DESCRIPTION
## Description ##
This PR aims to fix 2 things.

Docker yarn v1 -> v3 upgrade
------------------------------
Danny kindly helped us move our Docker from yarn v1 to yarn v3 to match our deployment pipelines.

Bug fix for radio buttons
-------------------------
Bug in production, deployment environments which stopped our govuk radio buttons working correctly. The buttons sometimes had conditional fields attached to them, so that choosing Yes or No would display or hide certain fields.

For some reason, an update to pdfjs-dist && webpack has caused that functionality to break in our environments (all excluding local). This is causing our nightly tests to fail and causing issues for our citizen users.

The fix for this is to downgrade the pdfjs-dist lib on our service from 4.x.xxx to 3.x.xxx, while we investigate further why updating this lib along with webpack broke our service.

## JIRA Ticket
https://tools.hmcts.net/jira/browse/NFDIV-3856