### PR TITLE
Upgrade pdfjs-dist to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "node-cache": "5.1.2",
     "nunjucks": "3.2.4",
     "otplib": "12.0.1",
-    "pdfjs-dist": "3.11.174",
+    "pdfjs-dist": "4.0.379",
     "redis": "4.6.12",
     "require-directory": "2.1.1",
     "serve-favicon": "2.5.0",

--- a/src/main/assets/js/pdfjs.ts
+++ b/src/main/assets/js/pdfjs.ts
@@ -1,12 +1,12 @@
-import * as pdfjsLib from 'pdfjs-dist';
-import 'pdfjs-dist/build/pdf.worker.js';
+import * as pdfjs from 'pdfjs-dist/build/pdf.mjs';
+import 'pdfjs-dist/build/pdf.worker.mjs';
 
-pdfjsLib.GlobalWorkerOptions.workerSrc = '/assets/pdf/pdf.worker.js';
+pdfjs.workerSrc = '/assets/pdf/pdf.worker.mjs';
 
 const loadingMsg = document.getElementById('loading-msg') as HTMLDivElement;
 const pdfContainer = document.getElementById('pdf-container') as HTMLDivElement;
 if (pdfContainer) {
-  pdfjsLib.getDocument('/downloads/respondent-answers').promise.then(
+  pdfjs.getDocument('/downloads/respondent-answers').promise.then(
     async pdfDocument => {
       console.log('PDF loaded');
       const pdf = new PdfDocument(pdfDocument);

--- a/webpack/app.js
+++ b/webpack/app.js
@@ -6,7 +6,7 @@ const root = path.resolve(__dirname, './../../');
 const sass = path.resolve(root, './main/assets/scss');
 const images = path.resolve(__dirname, '../src/main/assets/images');
 const locales = path.resolve(__dirname, '../src/main/assets/locales');
-const pdfWorker = path.resolve(__dirname, '../node_modules/pdfjs-dist/build/pdf.worker.js');
+const pdfWorker = path.resolve(__dirname, '../node_modules/pdfjs-dist/build/pdf.worker.mjs');
 
 const copyImages = new CopyWebpackPlugin({
   patterns: [{ from: images, to: 'img' }],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11097,7 +11097,7 @@ __metadata:
     nunjucks: 3.2.4
     otplib: 12.0.1
     pa11y: 7.0.0
-    pdfjs-dist: 3.11.174
+    pdfjs-dist: 4.0.379
     prettier: 3.1.1
     redis: 4.6.12
     require-directory: 2.1.1
@@ -12089,9 +12089,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pdfjs-dist@npm:3.11.174":
-  version: 3.11.174
-  resolution: "pdfjs-dist@npm:3.11.174"
+"pdfjs-dist@npm:4.0.379":
+  version: 4.0.379
+  resolution: "pdfjs-dist@npm:4.0.379"
   dependencies:
     canvas: ^2.11.2
     path2d-polyfill: ^2.0.1
@@ -12100,7 +12100,7 @@ __metadata:
       optional: true
     path2d-polyfill:
       optional: true
-  checksum: 62f5a64ca0b2dbc855701ebf9a65c3e48c3c9aa5d64c50eb42bb9ff50a326f3eddab7f2a134ef0398398b1ccff9d842935b9f31358c9103bdc71406632d1a7fa
+  checksum: dc40e9251c4fa178bb54e655ecf370393c913cc276b1444f7314bb856004727c9bde69b7de4bccb4884da3ed0ea2613029d130bcc4c7e4ddc1c842187927734c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Change description ###

Previously the update was broken was GlobalWorkerOptions was undefined and null. Rework to try and fix this issue.

I used this linked issue for suggestions on how to fix it.
https://github.com/vercel/next.js/issues/58313

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3856