### PR TITLE
Use coApplicant1IsSubmitted when checking whether a CO has been submi…

### DIFF
--- a/src/main/app/case/case.ts
+++ b/src/main/app/case/case.ts
@@ -156,6 +156,8 @@ export const formFieldsToCaseMapping: Partial<Record<keyof Case, keyof CaseData>
   dateSubmitted: 'dateSubmitted',
   dateAosSubmitted: 'dateAosSubmitted',
   dateFinalOrderSubmitted: 'dateFinalOrderSubmitted',
+  coApplicant1IsSubmitted: 'coApplicant1IsSubmitted',
+  coApplicant2IsSubmitted: 'coApplicant2IsSubmitted',
   coApplicant1SubmittedDate: 'coApplicant1SubmittedDate',
   coApplicant2SubmittedDate: 'coApplicant2SubmittedDate',
   dateFinalOrderEligibleFrom: 'dateFinalOrderEligibleFrom',
@@ -340,6 +342,8 @@ export interface Case {
   dateFinalOrderEligibleFrom: DateAsString;
   coCertificateOfEntitlementDocument: DivorceDocument;
   coConditionalOrderGrantedDocument: DivorceDocument;
+  coApplicant1IsSubmitted: YesOrNo;
+  coApplicant2IsSubmitted: YesOrNo;
   coApplicant1SubmittedDate?: DateAsString;
   coApplicant2SubmittedDate?: DateAsString;
   coRefusalRejectionAdditionalInfo?: string;

--- a/src/main/steps/applicant1/hub-page/sole/soleTemplateSelector.ts
+++ b/src/main/steps/applicant1/hub-page/sole/soleTemplateSelector.ts
@@ -43,7 +43,7 @@ export const getSoleHubTemplate = (
         return HubTemplate.FinalOrderRequested;
       } else if (userCase.coGrantedDate) {
         return HubTemplate.ConditionalOrderPronounced;
-      } else if (userCase.coApplicant1SubmittedDate || userCase.coApplicant2SubmittedDate) {
+      } else if (userCase.coApplicant1IsSubmitted === YesOrNo.YES || userCase.coApplicant2IsSubmitted === YesOrNo.YES) {
         return HubTemplate.AwaitingConditionalOrder;
       } else if (!userCase.dueDate && userCase.aosStatementOfTruth) {
         return HubTemplate.AwaitingGeneralConsideration;

--- a/src/main/steps/home/get.ts
+++ b/src/main/steps/home/get.ts
@@ -84,7 +84,7 @@ const applicant1RedirectPageSwitch = (userCase: Partial<CaseWithId>, isFirstQues
     }
     case State.ConditionalOrderDrafted:
     case State.ConditionalOrderPending: {
-      if (userCase.coApplicant1SubmittedDate) {
+      if (userCase.coApplicant1IsSubmitted === YesOrNo.YES) {
         return isSolicitorRepresented ? APP_REPRESENTED : HUB_PAGE;
       } else if (userCase.applicant1ApplyForConditionalOrder) {
         return CHECK_CONDITIONAL_ORDER_ANSWERS_URL;


### PR DESCRIPTION
### Change description ###
We use different case fields when checking whether a co has been submitted in the backend and frontend. Updating the frontend for consistency with the backend, as this will make our backend event to reset CO flags for EXUI users work for citizen users as well.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-4398

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

