### PR TITLE
NFDIV-4430 - Configure workflow to mark PRs stale or closed

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '30 15 * * *' # Runs at 3PM every day
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          close-issue-message: >
+            This issue has been automatically closed because it has been stalled for 2 days
+            with no activity.
+          close-pr-message: >
+            This issue has been automatically closed because it has been stalled for 2 days
+            with no activity.
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          days-before-close: '2'
+          days-before-stale: '12'
+          exempt-pr-labels: 'pinned,dependencies'
+          debug-only: 'true'


### PR DESCRIPTION
### Change description ###

Configure workflow to mark PRs stale or closed. Running in debug mode so PRs are not actually impacted by the next few runs

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-4430


